### PR TITLE
Implement q-digest algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ pdsa/cardinality/linear_counter.cpp
 pdsa/cardinality/probabilistic_counter.cpp
 pdsa/membership/bloom_filter.cpp
 pdsa/membership/counting_bloom_filter.cpp
+pdsa/rank/qdigest.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,4 +18,5 @@ global-exclude pdsa/membership/counting_bloom_filter.cpp
 global-exclude pdsa/helpers/hashing/mmh.cpp
 global-exclude pdsa/helpers/storage/bitvector.cpp
 global-exclude pdsa/helpers/storage/bitvector_counter.cpp
+global-exclude pdsa/rank/qdigest.cpp
 

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,8 @@ the error probability.
 The potential losses or errors are fully compensated by extremely
 low memory requirements, constant query time and scaling.
 
+GitHub repository: `<https://github.com/gakhov/pdsa>`_
+
 
 Dependencies
 ---------------------
@@ -62,6 +64,10 @@ The latest documentation can be found at `<http://pdsa.readthedocs.io/en/latest/
 
 - `Linear counter <http://pdsa.readthedocs.io/en/latest/cardinality/linear_counter.html>`_
 - `Probabilistic counter (Flajolet–Martin algorithm) <http://pdsa.readthedocs.io/en/latest/cardinality/probabilistic_counter.html>`_
+
+**Rank problem**
+
+- `q-digest <http://pdsa.readthedocs.io/en/latest/rank/qdigest.html>`_
 
 
 License

--- a/docs/rank/index.rst
+++ b/docs/rank/index.rst
@@ -1,0 +1,10 @@
+Rank
+==========
+
+The most commonly used rank characteristics are quantiles, and their 
+specific types as percentiles and quartiles.
+
+.. toctree::
+   :maxdepth: 2
+
+   qdigest

--- a/docs/rank/qdigest.rst
+++ b/docs/rank/qdigest.rst
@@ -24,9 +24,9 @@ from sensors.
 Build a q-digest
 ----------------
 
-Quantile Digest is designed to be build on integer numbers from known range.
+Quantile Digest is designed to be built on integer numbers from a known range.
 
-The range of the supported integers is defined by number of bytes in
+The range of the supported integers is defined by the number of bytes in thier
 maximal representation. Thus, for k-bytes integers, the range will
 be [0, 2^k - 1].
 
@@ -55,7 +55,7 @@ Quantile Query
 ---------------
 
 Given a fraction ``q`` from [0, 1], the quantile query
-is about to find the value whose rank in sorted sequence
+is about to find the value whose rank in a sorted sequence
 of the ``n`` values is ``q * n``.
 
 
@@ -79,7 +79,7 @@ Interval (range) Query
 -----------------------
 
 Given a value the interval (range) query
-is about to find number of elements in the given range
+is about to find the number of elements in the given range
 in the sequence of elements.
 
 .. code:: python
@@ -97,7 +97,7 @@ Merge q-digests
 
 .. warning::
 
-   Only q-digets with same compression_factor and range is possible to merge correctly.
+   Only q-digets with same compression_factor and range are possible to merge correctly.
 
 
 
@@ -122,8 +122,8 @@ Size of the q-digest in bytes
 
 .. warning::
 
-    Since we can't calculcate exact size of a dict in Cython,
-    this function return some estimation based on ideal size of
+    Since we can't calculate exact size of a dict in Cython,
+    this function return some estimation based an ideal size of
     keys, values of each bucket.
 
 

--- a/docs/rank/qdigest.rst
+++ b/docs/rank/qdigest.rst
@@ -24,12 +24,7 @@ from sensors.
 Build a q-digest
 ----------------
 
-Quantile Digest is designed to be build from integer numbers, so to
-support other objects we have to use hashing.
-
-
-Build q-digest from its range for integers only
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Quantile Digest is designed to be build on integer numbers from known range.
 
 The range of the supported integers is defined by number of bytes in
 maximal representation. Thus, for k-bytes integers, the range will
@@ -47,23 +42,6 @@ be [0, 2^k - 1].
    The ranges up to 32 bytes only are supported in the current implementation.
 
 
-
-Build q-digest with hashging
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-.. code:: python
-
-   from pdsa.rank.qdigest import QuantileDigest
-
-   qd = QuantileDigest().create_with_hashing(5)
-
-
-.. note::
-
-   Only 32-bytes MurmurHash3 is supported in the current implementation.
-
-
 Add element into q-digest
 -----------------------------
 
@@ -71,16 +49,6 @@ Add element into q-digest
 .. code:: python
 
     qd.add(5)
-
-
-.. note::
-
-   If using q-digest with hashing, all input elements a hashed and their
-   integer representation is actually stored in the q-digest.
-   It is possible to add into the q-digest any elements (internally
-   it uses *repr()* of the python object to calculate hash values for
-   elements that are not integers, strings or bytes.
-
 
 
 Quantile Query
@@ -144,6 +112,20 @@ Length of the q-digest is the number of buckets (nodes) included into the q-dige
     print(len(qd))
 
 
+Size of the q-digest in bytes
+------------------------------
+
+.. code:: python
+
+    print(qd.sizeof())
+
+
+.. warning::
+
+    Since we can't calculcate exact size of a dict in Cython,
+    this function return some estimation based on ideal size of
+    keys, values of each bucket.
+
 
 Count of elements in the q-digest
 ---------------------------------------
@@ -155,6 +137,6 @@ Count of elements in the q-digest
 
 .. warning::
 
-    While we can't say exactly which elements in the q-digest,
+    While we can't say exactly which elements are in the q-digest,
     (because the compression is a lossy operation), it's still
     possible to say how many in total elements were added.

--- a/docs/rank/qdigest.rst
+++ b/docs/rank/qdigest.rst
@@ -1,0 +1,160 @@
+Quantile Digest (q-digest)
+============================
+
+Quantile Digest, or q-digest, is a tree-based stream summary algorithm
+that was proposed by Nisheeth Shrivastava, Subhash Suri et al. in
+2004 in the context of monitoring distributed data
+from sensors.
+
+
+.. code:: python
+
+    from pdsa.rank.qdigest import QuantileDigest
+
+    qd = QuantileDigest(3, 5)
+    for i in range(100):
+        qd.add(random.randrange(0, 8))
+    qd.compress()
+
+    qd.quantile_query(0.5)
+    qd.inverse_quantile_query(5)
+    qd.interval_query(2, 6)
+
+
+Build a q-digest
+----------------
+
+Quantile Digest is designed to be build from integer numbers, so to
+support other objects we have to use hashing.
+
+
+Build q-digest from its range for integers only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The range of the supported integers is defined by number of bytes in
+maximal representation. Thus, for k-bytes integers, the range will
+be [0, 2^k - 1].
+
+.. code:: python
+
+   from pdsa.rank.qdigest import QuantileDigest
+
+   qd = QuantileDigest(3, 5)
+
+
+.. note::
+
+   The ranges up to 32 bytes only are supported in the current implementation.
+
+
+
+Build q-digest with hashging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. code:: python
+
+   from pdsa.rank.qdigest import QuantileDigest
+
+   qd = QuantileDigest().create_with_hashing(5)
+
+
+.. note::
+
+   Only 32-bytes MurmurHash3 is supported in the current implementation.
+
+
+Add element into q-digest
+-----------------------------
+
+
+.. code:: python
+
+    qd.add(5)
+
+
+.. note::
+
+   If using q-digest with hashing, all input elements a hashed and their
+   integer representation is actually stored in the q-digest.
+   It is possible to add into the q-digest any elements (internally
+   it uses *repr()* of the python object to calculate hash values for
+   elements that are not integers, strings or bytes.
+
+
+
+Quantile Query
+---------------
+
+Given a fraction ``q`` from [0, 1], the quantile query
+is about to find the value whose rank in sorted sequence
+of the ``n`` values is ``q * n``.
+
+
+.. code:: python
+
+    qd.quantile_query(0.95)
+
+
+Inverse Quantile Query
+-----------------------
+
+Given an element, the inverse quantile query
+is about to find its rank in sorted sequence of values.
+
+.. code:: python
+
+    qd.inverse_quantile_query(4)
+
+
+Interval (range) Query
+-----------------------
+
+Given a value the interval (range) query
+is about to find number of elements in the given range
+in the sequence of elements.
+
+.. code:: python
+
+    qd.interval_query(3, 6)
+
+
+Merge q-digests
+----------------
+
+.. code:: python
+
+    qd = qd1 + qd2
+
+
+.. warning::
+
+   Only q-digets with same compression_factor and range is available to be merged.
+
+
+
+Length of the q-digest
+----------------------
+
+Length of the q-digest is the number of buckets (nodes) included into the q-digest.
+
+
+.. code:: python
+
+    print(len(qd))
+
+
+
+Count of elements in the q-digest
+---------------------------------------
+
+.. code:: python
+
+    print(qd.count())
+
+
+.. warning::
+
+    While we can't say exactly which elements in the q-digest,
+    (because the compression is a lossy operation), it's still
+    possible to say how many in total elements were added.

--- a/docs/rank/qdigest.rst
+++ b/docs/rank/qdigest.rst
@@ -124,12 +124,12 @@ Merge q-digests
 
 .. code:: python
 
-    qd = qd1 + qd2
+    qd1.merge(qd2)
 
 
 .. warning::
 
-   Only q-digets with same compression_factor and range is available to be merged.
+   Only q-digets with same compression_factor and range is possible to merge correctly.
 
 
 

--- a/examples/rank/qdigest.py
+++ b/examples/rank/qdigest.py
@@ -1,0 +1,23 @@
+"""Example how to use QuantileDigest."""
+import random
+
+from pdsa.rank.qdigest import QuantileDigest
+
+if __name__ == '__main__':
+    qd = QuantileDigest(4, 5)
+
+    random.seed(42)
+    for i in range(100):
+        qd.add(random.randrange(0, 16))
+
+    qd.compress()
+
+    print(qd)
+    print("Total elements in the q-digest:", qd.count())
+
+    print("50th percentile (median):", qd.quantile_query(0.5))
+    print("95th percentile:", qd.quantile_query(0.95))
+
+    print("Rank of the element <10>:", qd.inverse_quantile_query(10))
+
+    print("Number of elements in [4, 9]:", qd.interval_query(4, 9))

--- a/examples/rank/qdigest.py
+++ b/examples/rank/qdigest.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
     qd.compress()
 
     print(qd)
+    print("Size in bytes of the q-digest:", qd.sizeof())
     print("Total elements in the q-digest:", qd.count())
 
     print("50th percentile (median):", qd.quantile_query(0.5))

--- a/pdsa/rank/__init__.py
+++ b/pdsa/rank/__init__.py
@@ -1,0 +1,4 @@
+from .qdigest import QuantileDigest
+
+
+__all__ = ["QuantileDigest"]

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -20,9 +20,9 @@ cdef class QuantileDigest:
     cpdef void add(self, object element, bint compress=*)
     cpdef void compress(self)
 
-    # cpdef void quantile_query(self, uint8_t quantile)
-    # cpdef void inverse_quantile_query(self, object element) except *
-    # cpdef void range_query(self, uint8_t r) except *
+    cpdef uint64_t quantile_query(self, float quantile) except *
+    cpdef size_t inverse_quantile_query(self, object element) except *
+    cpdef size_t interval_query(self, uint64_t start, uint64_t end) except *
 
     cpdef size_t sizeof(self)
     cpdef size_t count(self)
@@ -32,8 +32,10 @@ cdef class QuantileDigest:
     cdef uint64_t _bucket_parent_id(self, uint32_t bucket_id)
     cdef uint64_t _bucket_sibling_id(self, uint32_t bucket_id)
 
+    cdef uint32_t _bucket_level(self, uint64_t bucket_id)
+    cdef tuple _bucket_range(self, uint64_t bucket_id)
+
     cdef list _buckets_on_level(self, uint8_t level)
     cdef bint _merge_if_needed(self, uint64_t bucket_id)
     cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id) except *
     cdef bint _is_worth_to_store(self, size_t counts_sum)
-

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -1,0 +1,21 @@
+from libc.stdint cimport uint32_t, uint8_t
+
+cdef class QuantileDigest:
+    cdef uint8_t _compression factor
+    cdef uint32_t _min_range
+    cdef uint32_t _max_range
+
+    cdef uint8_t _seed
+
+    cpdef void add(self, object element, bint compress=*) except *
+    cpdef void compress(self, object element) except *
+
+    cpdef void quantile_query(self, uint8_t quantile) except *
+    cpdef void inverse_quantile_query(self, object element) except *
+    cpdef void range_query(self, uint8_t r) except *
+    
+    cpdef size_t sizeof(self)
+    cpdef size_t total(self)
+
+    cdef uint32_t _hash(self, object element, uint8_t seed)
+

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -1,27 +1,30 @@
-from libc.stdint cimport uint32_t, uint8_t
+from libc.stdint cimport uint64_t, uint32_t, uint8_t
 
 cdef class QuantileDigest:
     cdef uint8_t _compression_factor
     cdef uint32_t _min_range
     cdef uint32_t _max_range
     cdef uint8_t _tree_height
-    cdef uint32_t _number_of_nodes
+    cdef uint64_t _number_of_nodes
+    cdef uint8_t _range_in_bits
+    cdef size_t _total
 
-    cdef uint8_t _seed
+    cdef dict _qdigest
+    # cdef uint8_t _seed
 
-    cpdef void add(self, object element, bint compress=*) except *
+    cpdef void add(self, uint32_t element, bint compress=*) except *
     cpdef void compress(self) except *
 
     # cpdef void quantile_query(self, uint8_t quantile) except *
     # cpdef void inverse_quantile_query(self, object element) except *
     # cpdef void range_query(self, uint8_t r) except *
-    
+
     # cpdef size_t sizeof(self)
     # cpdef size_t total(self)
 
-    cdef uint32_t _hash(self, object element, uint8_t seed)
-    # def get_all_on_level(self, uint8_t level)
-    cdef bint merge_if_needed(self, uint32_t bucket_id)
+    # cdef uint32_t _hash(self, object element, uint8_t seed)
+    cdef list buckets_on_level(self, uint8_t level)
+    cdef bint merge_if_needed(self, uint64_t bucket_id)
     cdef bint qdigest_property(self, size_t counts_sum)
-    cdef uint32_t _bucket_id(self, uint32_t value)
+    cdef uint64_t _bucket_id(self, uint32_t value)
 

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -17,7 +17,7 @@ cdef class QuantileDigest:
     cdef dict _qdigest
     cdef uint8_t _seed
 
-    cpdef void add(self, object element, bint compress=*)
+    cpdef void add(self, object element, bint compress=*) except *
     cpdef void compress(self)
 
     cpdef uint64_t quantile_query(self, float quantile) except *
@@ -26,7 +26,7 @@ cdef class QuantileDigest:
 
     cpdef size_t sizeof(self)
     cpdef size_t count(self)
-    cpdef void merge(self, QuantileDigest other)
+    cpdef void merge(self, QuantileDigest other) except *
 
     cdef uint32_t _hash(self, object element, uint8_t seed)
     cdef uint64_t _bucket_canonical_id(self, uint32_t value)

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -1,30 +1,39 @@
 from libc.stdint cimport uint64_t, uint32_t, uint8_t
 
 cdef class QuantileDigest:
-    cdef uint8_t _compression_factor
+    cdef uint8_t compression_factor
+    cdef uint8_t range_in_bits
+    cdef bint with_hashing
+
     cdef uint32_t _min_range
     cdef uint32_t _max_range
+
     cdef uint8_t _tree_height
-    cdef uint64_t _number_of_nodes
-    cdef uint8_t _range_in_bits
-    cdef size_t _total
+    cdef uint64_t _max_number_of_nodes
+
+    cdef uint64_t _number_of_buckets
+    cdef float _exact_boundary_value
 
     cdef dict _qdigest
-    # cdef uint8_t _seed
+    cdef uint8_t _seed
 
-    cpdef void add(self, uint32_t element, bint compress=*) except *
+    cpdef void add(self, object element, bint compress=*) except *
     cpdef void compress(self) except *
 
     # cpdef void quantile_query(self, uint8_t quantile) except *
     # cpdef void inverse_quantile_query(self, object element) except *
     # cpdef void range_query(self, uint8_t r) except *
 
-    # cpdef size_t sizeof(self)
-    # cpdef size_t total(self)
+    cpdef size_t sizeof(self)
+    cpdef size_t count(self)
 
-    # cdef uint32_t _hash(self, object element, uint8_t seed)
-    cdef list buckets_on_level(self, uint8_t level)
-    cdef bint merge_if_needed(self, uint64_t bucket_id)
-    cdef bint qdigest_property(self, size_t counts_sum)
-    cdef uint64_t _bucket_id(self, uint32_t value)
+    cdef uint32_t _hash(self, object element, uint8_t seed)
+    cdef uint64_t _bucket_canonical_id(self, uint32_t value)
+    cdef uint64_t _bucket_parent_id(self, uint32_t bucket_id)
+    cdef uint64_t _bucket_sibling_id(self, uint32_t bucket_id)
+
+    cdef list _buckets_on_level(self, uint8_t level)
+    cdef bint _merge_if_needed(self, uint64_t bucket_id)
+    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id)
+    cdef bint _is_worth_to_store(self, size_t counts_sum)
 

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -26,6 +26,7 @@ cdef class QuantileDigest:
 
     cpdef size_t sizeof(self)
     cpdef size_t count(self)
+    cpdef void merge(self, QuantileDigest other)
 
     cdef uint32_t _hash(self, object element, uint8_t seed)
     cdef uint64_t _bucket_canonical_id(self, uint32_t value)

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -1,21 +1,27 @@
 from libc.stdint cimport uint32_t, uint8_t
 
 cdef class QuantileDigest:
-    cdef uint8_t _compression factor
+    cdef uint8_t _compression_factor
     cdef uint32_t _min_range
     cdef uint32_t _max_range
+    cdef uint8_t _tree_height
+    cdef uint32_t _number_of_nodes
 
     cdef uint8_t _seed
 
     cpdef void add(self, object element, bint compress=*) except *
-    cpdef void compress(self, object element) except *
+    cpdef void compress(self) except *
 
-    cpdef void quantile_query(self, uint8_t quantile) except *
-    cpdef void inverse_quantile_query(self, object element) except *
-    cpdef void range_query(self, uint8_t r) except *
+    # cpdef void quantile_query(self, uint8_t quantile) except *
+    # cpdef void inverse_quantile_query(self, object element) except *
+    # cpdef void range_query(self, uint8_t r) except *
     
-    cpdef size_t sizeof(self)
-    cpdef size_t total(self)
+    # cpdef size_t sizeof(self)
+    # cpdef size_t total(self)
 
     cdef uint32_t _hash(self, object element, uint8_t seed)
+    # def get_all_on_level(self, uint8_t level)
+    cdef bint merge_if_needed(self, uint32_t bucket_id)
+    cdef bint qdigest_property(self, size_t counts_sum)
+    cdef uint32_t _bucket_id(self, uint32_t value)
 

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -3,7 +3,6 @@ from libc.stdint cimport uint64_t, uint32_t, uint8_t
 cdef class QuantileDigest:
     cdef uint8_t compression_factor
     cdef uint8_t range_in_bits
-    cdef bint with_hashing
 
     cdef uint32_t _min_range
     cdef uint32_t _max_range
@@ -15,25 +14,23 @@ cdef class QuantileDigest:
     cdef float _exact_boundary_value
 
     cdef dict _qdigest
-    cdef uint8_t _seed
 
-    cpdef void add(self, object element, bint compress=*) except *
+    cpdef void add(self, uint32_t element, bint compress=*) except *
     cpdef void compress(self)
 
-    cpdef uint64_t quantile_query(self, float quantile) except *
-    cpdef size_t inverse_quantile_query(self, object element) except *
-    cpdef size_t interval_query(self, uint64_t start, uint64_t end) except *
+    cpdef uint32_t quantile_query(self, float quantile) except *
+    cpdef size_t inverse_quantile_query(self, uint32_t element) except *
+    cpdef size_t interval_query(self, uint32_t start, uint32_t end) except *
 
     cpdef size_t sizeof(self)
     cpdef size_t count(self)
     cpdef void merge(self, QuantileDigest other) except *
 
-    cdef uint32_t _hash(self, object element, uint8_t seed)
     cdef uint64_t _bucket_canonical_id(self, uint32_t value)
     cdef uint64_t _bucket_parent_id(self, uint32_t bucket_id)
     cdef uint64_t _bucket_sibling_id(self, uint32_t bucket_id)
 
-    cdef uint32_t _bucket_level(self, uint64_t bucket_id)
+    cdef uint8_t _bucket_level(self, uint64_t bucket_id)
     cdef tuple _bucket_range(self, uint64_t bucket_id)
 
     cdef list _buckets_on_level(self, uint8_t level)

--- a/pdsa/rank/qdigest.pxd
+++ b/pdsa/rank/qdigest.pxd
@@ -17,10 +17,10 @@ cdef class QuantileDigest:
     cdef dict _qdigest
     cdef uint8_t _seed
 
-    cpdef void add(self, object element, bint compress=*) except *
-    cpdef void compress(self) except *
+    cpdef void add(self, object element, bint compress=*)
+    cpdef void compress(self)
 
-    # cpdef void quantile_query(self, uint8_t quantile) except *
+    # cpdef void quantile_query(self, uint8_t quantile)
     # cpdef void inverse_quantile_query(self, object element) except *
     # cpdef void range_query(self, uint8_t r) except *
 
@@ -34,6 +34,6 @@ cdef class QuantileDigest:
 
     cdef list _buckets_on_level(self, uint8_t level)
     cdef bint _merge_if_needed(self, uint64_t bucket_id)
-    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id)
+    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id) except *
     cdef bint _is_worth_to_store(self, size_t counts_sum)
 

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -91,10 +91,10 @@ cdef class QuantileDigest:
         self.with_hashing = enable_hashing
 
         self._min_range = 0
-        self._max_range = 1 << self.range_in_bits - 1
+        self._max_range = (<uint64_t>1 << self.range_in_bits) - 1
 
         self._tree_height = self.range_in_bits + 1
-        self._max_number_of_nodes = 1 << self._tree_height - 1
+        self._max_number_of_nodes = (<uint64_t>1 << self._tree_height) - 1
 
         self._number_of_buckets = 0
         self._exact_boundary_value = 0
@@ -159,7 +159,7 @@ cdef class QuantileDigest:
         Parameters
         ----------
         bucket_id : :obj:`int`
-            The bucket ID of the bucket whose parent is computed.
+            The bucket ID of the bucket whose parent is to be computed.
 
         Returns
         -------
@@ -180,7 +180,7 @@ cdef class QuantileDigest:
         Parameters
         ----------
         bucket_id : :obj:`int`
-            The bucket ID of the bucket whose sibling is computed.
+            The bucket ID of the bucket whose sibling is to be computed.
 
         Note
         ----
@@ -222,8 +222,8 @@ cdef class QuantileDigest:
             indices 2^{k-1} .. 2^{k} - 1.
 
         """
-        cdef uint64_t bucket_ids_start = 1 << (level - 1)
-        cdef uint64_t bucket_ids_end = 2 * bucket_ids_start -  1
+        cdef uint64_t bucket_ids_start = <uint64_t>1 << (level - 1)
+        cdef uint64_t bucket_ids_end = 2 * bucket_ids_start - 1
 
         # NOTE: We iterate over q-digest (instead of the tree)
         # since it has less buckets than the average level of full tree.
@@ -473,9 +473,6 @@ cdef class QuantileDigest:
         """
         return self._number_of_buckets
 
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    @cython.cdivision(True)
     cpdef size_t count(self):
         """Number of elements (incl. duplicates) in the q-digest.
 
@@ -503,3 +500,4 @@ cdef class QuantileDigest:
 
         """
         raise NotImplementedError
+

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -471,11 +471,8 @@ cdef class QuantileDigest:
             The compression of q-digest is made by merge procedure
             (bottom up) according to q-digest property.
 
-            If number of nodes in the digest is less than the
-            compression factor, then there is no sense to compress.
-
         """
-        if self._number_of_buckets <= self.compression_factor:
+        if self._number_of_buckets < 2:
             return
 
         cdef uint8_t level =  self._tree_height

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -1,3 +1,21 @@
+"""
+
+Quantile Digest.
+
+Quantile Digest or q-digest is a tree-based stream summary algorithm
+that was proposed by Nisheeth Shrivastava, Subhash Suri et al. in
+2004 in the context of monitoring distributed data
+from sensors.
+
+References
+----------
+[1] Shrivastava, N., et al
+    Medians and Beyond: New Aggregation Techniques for Sensor Networks.
+    Proceedings of the 2nd International Conference on Embedded Networked Sensor Systems,
+    Baltimore, MD, USA - November 03–05, 2004, pp. 58–66, ACM New York, NY (2004)
+    https://www.inf.fu-berlin.de/lehre/WS11/Wireless/papers/AgrQdigest.pdf
+"""
+
 import cython
 
 from libc.math cimport floor, log, round
@@ -6,158 +24,196 @@ from libc.stdlib cimport rand
 
 from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
 
+cdef uint8_t ROOT_BUCKET = 1
+
 
 cdef class QuantileDigest:
+    """QuantileDigest is a realisation of q-digest algorithm.
 
-    def __cinit__(self, const uint8_t range_in_bits, const uint8_t compression_factor):
-        """Create qdigest with requested compression factor.
+    Example
+    -------
 
-        """
-        if compression_factor < 1:
-            raise ValueError("Compression factor")
+    >>> from pdsa.rank.qdigest import QuantileDigest
 
-        self._compression_factor = compression_factor
-        self._range_in_bits = range_in_bits
-        self._min_range = 0
-        self._max_range = 2**self._range_in_bits - 1
+    >>> qd = QuantileDigest(16, 5)
+    >>> qd.add(42)
+    >>> qd.merge()
 
-        self._tree_height = self._range_in_bits + 1
-        self._number_of_nodes = 2**self._tree_height - 1
-        self._total = 0
 
-        # self._seed = <uint8_t>(rand())
+    Note
+    -----
+        If requested, this implementation uses MurmurHash3 family of
+        hash functions which yields a 32-bit hash value.
 
-        # print(UINT32_MAX, self._max_range)
-        # print("_number_of_nodes", self._number_of_nodes)
-        # print("height", self._tree_height)
+    Attributes
+    ----------
+    range_in_bits : :obj:`int`
+        The maximal supported input non-negative integer values in bits.
+    compression_factor : :obj:`int`
+        The level of the compression in q-digest.
 
-        self._qdigest = {}
+    """
 
-    # cdef uint32_t _hash(self, object key, uint8_t seed):
-    #     # self.algorithm = "mmh3_x86_32bit"
-    #     # return mmh3_x86_32bit(key, seed)
-    #     return <uint32_t>key
-
-    cdef uint64_t _bucket_id(self, uint32_t value):
-        # In the full and complete binary tree build for the
-        # binary parition of a range [0 .. self._max_range]
-        # is the value-th value (from left) in the last level (=height).
-        # The index of the first node (from left to right)
-        # at the last level is _number_of_nodes - self._max_range
-        # (because exactly self._max_range nodes at the last level).
-        return self._number_of_nodes - self._max_range + value
-
-    cpdef void add(self, uint32_t element, bint compress=False) except *:
-        # cdef uint32_t hashed = self._hash(element, self._seed)
-        # if hashed > self._max_range or hashed < self._min_range:
-        #     raise ValueError("Value out of range")
-
-        cdef uint64_t canonical_bucket_id = self._bucket_id(element)
-
-        path = []
-        cdef uint64_t bucket_id = canonical_bucket_id
-        cdef uint64_t closest_parent_id_in_digest = 0
-        while bucket_id > 0:
-            if bucket_id in self._qdigest:
-                closest_parent_id_in_digest = bucket_id
-                break
-            bucket_id = bucket_id // 2  # get parent
-
-        # assert closest_parent_id_in_digest > 0
-
-        if closest_parent_id_in_digest == canonical_bucket_id:
-            self._qdigest[canonical_bucket_id] += 1  # update counts
-        else:
-            self._qdigest[canonical_bucket_id] = 1
-            bucket_id = canonical_bucket_id
-            while bucket_id > 0:
-                bucket_id = bucket_id // 2
-                if bucket_id <= closest_parent_id_in_digest:
-                    break
-                self._qdigest[bucket_id] = 0
-
-        self._total += 1
-
-        if compress:
-            self.compress()
-
-    cdef bint qdigest_property(self, size_t counts_sum):
-        cdef size_t boundary_value = <size_t>(floor(self._total / float(self._compression_factor)))
-        boundary_value = max(<uint8_t>1, boundary_value)
-        if counts_sum <= boundary_value:
-            return False
-        return True
-
-    def debug(self):
-        return self._qdigest
-
-    cdef bint merge_if_needed(self, uint64_t current_bucket_id):
-        if current_bucket_id == 1:
-            return False
-
-        cdef uint64_t parent_bucket_id
-        cdef uint64_t sibling_bucket_id
-        cdef uint8_t current_bucket_shift
-
-        # i // 2 -> [2*i//2 + 0, 2*i//2 +1]
-
-        parent_bucket_id, current_bucket_shift = divmod(
-            current_bucket_id, 2)
-
-        sibling_bucket_id = 2 * parent_bucket_id + current_bucket_shift ^ 1
-
-        if current_bucket_id not in self._qdigest:
-            # NOTE: might be already removed from the QDigest
-            # after merging because of its sibling
-            return False
-
-        cdef size_t bucket_counts = self._qdigest[current_bucket_id]
-        cdef size_t bucket_parent_counts = self._qdigest.get(
-            parent_bucket_id, 0)
-        cdef size_t bucket_sibling_counts = self._qdigest.get(
-            sibling_bucket_id, 0)
-
-        cdef size_t counts = bucket_counts + bucket_parent_counts + bucket_sibling_counts
-        if self.qdigest_property(counts):
-            return False
-
-        print("count", counts, "<<<", bucket_counts, bucket_sibling_counts, bucket_parent_counts)
-        print("merge", parent_bucket_id, "<==", current_bucket_id, sibling_bucket_id)
-
-        if parent_bucket_id not in self._qdigest:
-            self._total += 1
-
-        self._qdigest[parent_bucket_id] = counts
-
-        try:
-            del self._qdigest[current_bucket_id]
-        except:
-            pass
-        else:
-            self._total -= 1
-
-        try:
-            del self._qdigest[sibling_bucket_id]
-        except:
-            pass
-        else:
-            self._total -= 1
-
-        return True
-
-    cdef list buckets_on_level(self, uint8_t level):
-        """Get all buckets from qdigest that are on the `level`.
+    def __cinit__(self, const uint8_t range_in_bits, const uint8_t compression_factor,
+                  const bint enable_hashing=False):
+        """Create a q-digest with a requested compression factor.
 
         Parameters
         ----------
-        level : `int`
-            The level index.
+        range_in_bits : :obj:`int`
+            The maximal supported input non-negative integer values in bits.
+        compression_factor : :obj:`int`
+            The level of the compression in q-digest.
+        enable_hashing : bool
+            A flag to enable hashing of input values (to support non-integers).
+
+        Raises
+        ------
+        ValueError
+            If `compression_factor` is 0 or negative.
+        ValueError
+            If hashing is required, but `range_in_bits` differs from 32.
+        ValueError
+            If `range_in_bits` is bigger than 32.
+
+        """
+        if compression_factor < 1:
+            raise ValueError("Compression factor is too small")
+
+        if enable_hashing and range_in_bits != 32:
+            raise ValueError("Only 32-bit hashing is supported")
+
+        if range_in_bits > 32:
+            raise ValueError("Only ranges up to 2^{32} are supported")
+
+        self.compression_factor = compression_factor
+        self.range_in_bits = range_in_bits
+        self.with_hashing = enable_hashing
+
+        self._min_range = 0
+        self._max_range = 2**self.range_in_bits - 1
+
+        self._tree_height = self.range_in_bits + 1
+        self._max_number_of_nodes = 2**self._tree_height - 1
+
+        self._number_of_buckets = 0
+        self._exact_boundary_value = 0
+
+        self._seed = <uint8_t>(rand())
+        self._qdigest = {}
+
+    @classmethod
+    def create_with_hashing(cls, const uint8_t compression_factor):
+        """Create QuantileDigest that supports arbitrary types of inputs.
+
+        Parameters
+        ----------
+        compression_factor : :obj:`int`
+            The level of the compression in q-digest.
+
+        Note
+        ----
+            Currently, we offer only 32-bit hash function that defines
+            the range of the q-digest.
+
+        """
+        return cls(32, compression_factor, enable_hashing=True)
+
+    cdef uint32_t _hash(self, object key, uint8_t seed):
+        # self.algorithm = "mmh3_x86_32bit"
+        # return mmh3_x86_32bit(key, seed)
+        return <uint32_t>key
+
+    cdef uint64_t _bucket_canonical_id(self, uint32_t value):
+        """Compute the canonical bucket for the input value.
+
+        Parameters
+        ----------
+        value : :obj:`int`
+            The input value in the supported range.
 
         Returns
         -------
-        :obj:list
-            List of bucket ids from level `level` that are included in
-            qdigest data structure.
+        :obj:`int`
+            The ID of the canonical bucket.
+
+        Note
+        ----
+            In the full and complete binary tree build for the
+            binary parition of a range [0 .. self._max_range]
+            is the value-th value (from left) in the last level (=height).
+
+            The canonical bucket is a leaf bucket for the inserted value.
+
+            The index of the first node (from left to right)
+            at the last level is self._max_number_of_nodes - self._max_range
+            (because exactly self._max_range nodes at the last level).\
+
+        """
+        return self._max_number_of_nodes - self._max_range + value
+
+    @cython.cdivision(True)
+    cdef uint64_t _bucket_parent_id(self, uint32_t bucket_id):
+        """Compute the parent of the bucket.
+
+        Parameters
+        ----------
+        bucket_id : :obj:`int`
+            The bucket ID of the bucket whose parent is computed.
+
+        Returns
+        -------
+        :obj:`int`
+            The ID of the bucket's parent.
+
+        Note
+        ----
+            In the full and complete binary tree build parent ID can be
+            computed as integer division by 2 of the bucket's ID.
+
+        """
+        return bucket_id // 2
+
+    cdef uint64_t _bucket_sibling_id(self, uint32_t bucket_id):
+        """Compute the parent of the bucket.
+
+        Parameters
+        ----------
+        bucket_id : :obj:`int`
+            The bucket ID of the bucket whose sibling is computed.
+
+        Note
+        ----
+            In the full and complete binary tree build every parent bucket
+            has exactly 2 children. Suppose, the parent id is `i`, then
+            children have ids `2 * i` and `2 * i + 1`. Thus, the id of the
+            sibling can be computed by the XOR of binary shift of the
+            current bucket ID.
+
+        Returns
+        -------
+        :obj:`int`
+            The ID of the bucket's sibling.
+
+        """
+        cdef uint64_t parent_bucket_id = self._bucket_parent_id(bucket_id)
+        cdef uint8_t current_bucket_shift = bucket_id % 2
+
+        return 2 * parent_bucket_id + current_bucket_shift ^ 1
+
+    cdef list _buckets_on_level(self, uint8_t level):
+        """Get all buckets from q-digest that exist on the level `level`.
+
+        Parameters
+        ----------
+        level : :obj:`int`
+            The `level` index.
+
+        Returns
+        -------
+        list
+            List of bucket IDs from level `level` that are included in
+            q-digest data structure.
 
         Note
         ----
@@ -169,58 +225,281 @@ cdef class QuantileDigest:
         cdef uint64_t bucket_ids_start = 2**(level - 1)
         cdef uint64_t bucket_ids_end = 2 * bucket_ids_start -  1
 
-        # we iterate over qdigest since it has less buckets,
-        # then the average level (may be do that only if layer > X)
+        # NOTE: We iterate over q-digest (instead of the tree)
+        # since it has less buckets than the average level of full tree.
+        # TODO: Does it make sense to iterate over all possible buckets'
+        # ids if level is low (e.g., if layer < 5)
+
         cdef list buckets = []
         for bucket_id in self._qdigest:
             if bucket_ids_start <= bucket_id <= bucket_ids_end:
                 buckets.append(bucket_id)
         return buckets
 
+    @cython.cdivision(True)
+    cpdef void add(self, object element, bint compress=False) except *:
+        """Add element into the q-digest.
+
+        Parameters
+        ----------
+        element : obj
+            The input element. If hashing is not enabled the `element`
+            will be automatically cast to uint32_t.
+        compress : :obj:bint
+            A flag to automatically compress q-digest structure after
+            the addition is finished.
+
+        Note
+        ----
+            By default, the q-digest isn't automatically compressed to
+            optimize the complexity of the addition, especially in the
+            cases when many elements are added sequentially without
+            performing any rank queries to the data structure.
+
+            We always insert a leaf bucket (canonical) for the input element
+            and, if any, all missing parent nodes in the hierarchy (bottom up).
+
+        Raises
+        ------
+        ValueError
+            If value of the element is out of range.
+
+        """
+        cdef uint32_t value
+
+        if not self.with_hashing:
+            value = <uint32_t>element
+        else:
+            value = self._hash(element, self._seed)
+
+        if value > self._max_range or value < self._min_range:
+            raise ValueError("Value out of range")
+
+        cdef uint64_t canonical_bucket_id = self._bucket_canonical_id(value)
+        cdef uint64_t bucket_id = canonical_bucket_id
+        cdef uint64_t closest_parent_id_in_digest = 0
+
+        # NOTE: search for the closest existing parent
+        while bucket_id > 0:
+            if bucket_id in self._qdigest:
+                closest_parent_id_in_digest = bucket_id
+                break
+            bucket_id = self._bucket_parent_id(bucket_id)
+
+        # NOTE: Update counts for the canonical bucket
+        # and create all missing parent nodes (with 0 counts)
+        # in the hierarhy (bottom up).
+        if closest_parent_id_in_digest == canonical_bucket_id:
+            self._qdigest[canonical_bucket_id] += 1
+        else:
+            self._number_of_buckets += 1
+            self._qdigest[canonical_bucket_id] = 1
+            bucket_id = canonical_bucket_id
+            while bucket_id > 0:
+                bucket_id = self._bucket_parent_id(bucket_id)
+                if bucket_id <= closest_parent_id_in_digest:
+                    break
+                self._qdigest[bucket_id] = 0
+                self._number_of_buckets += 1
+
+        self._exact_boundary_value += 1.0 / self.compression_factor
+
+        if compress:
+            self.compress()
+
+    cdef bint _is_worth_to_store(self, size_t family_counts):
+        """Decide if family of nodes with specified counts is worth to be stored.
+
+        Parameters
+        ----------
+        family_counts : :obj:`int`
+            The total counts of the family of nodes, parent and its 2
+            children.
+
+        Note
+        ----
+            If total counts of the family of nodes (parent and 2 children)
+            are satisfy the q-digest property, they are worth to be stored.
+
+            Boundary value for estimate significance of the counts in the
+            q-digest propery is related on the ratio between number of elements
+            already in the q-digest and current compression factor.
+
+        Returns
+        -------
+        bool
+            True if family of nodes is worth to be kept in the q-digest,
+            False otherwise.
+
+        """
+        cdef size_t boundary_value = max(
+            <uint8_t>1,
+            <size_t>floor(self._exact_boundary_value)
+        )
+        return family_counts > boundary_value
+
+    def debug(self):
+        """Return q-digest for debug purposes."""
+        return self._qdigest
+
+    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id):
+        """Delete bucket from q-digest if it's exists.
+
+        Parameters
+        ----------
+        bucket_id : :obj:`int`
+            The bucket to delete.
+
+        Note
+        ----
+            Everytime when bucket if deleted, the number_of_buckets
+            in the q-digest has to be decreased.
+
+        Returns
+        -------
+        bool
+            True if delete was performed, False otherwise.
+
+        """
+        try:
+            del self._qdigest[bucket_id]
+        except KeyError:
+            return False
+
+        self._number_of_buckets -= 1
+        return True
+
+    cdef bint _merge_if_needed(self, uint64_t current_bucket_id):
+        """Merge family of nodes for the bucket to its parent.
+
+        Parameters
+        ----------
+        current_bucket_id : :obj:`int`
+            The bucket whose family if evaluated.
+
+        Note
+        ----
+            To optimize q-digest, it's required to merge all non-significant
+            families of nodes (parent and its children) and keep information
+            about family counts at parent node only.
+
+        Returns
+        -------
+        bool
+            True if merge was performed, False otherwise.
+
+        """
+        # NOTE: Bucket might be already removed from the q-digest
+        # after merging its family by evaluating the sibling
+        if current_bucket_id not in self._qdigest:
+            return False
+
+        cdef size_t bucket_counts = self._qdigest[current_bucket_id]
+
+        if current_bucket_id == ROOT_BUCKET:
+            if bucket_counts <= 0:
+                self._delete_bucket_if_exists(ROOT_BUCKET)
+            return False
+
+        cdef uint64_t parent_bucket_id = self._bucket_parent_id(current_bucket_id)
+        cdef uint64_t sibling_bucket_id = self._bucket_sibling_id(current_bucket_id)
+
+        cdef size_t bucket_parent_counts = self._qdigest.get(
+            parent_bucket_id, 0)
+        cdef size_t bucket_sibling_counts = self._qdigest.get(
+            sibling_bucket_id, 0)
+
+        cdef size_t family_counts = bucket_counts\
+            + bucket_parent_counts\
+            + bucket_sibling_counts
+
+        if self._is_worth_to_store(family_counts):
+            return False
+
+        if parent_bucket_id not in self._qdigest:
+            self._number_of_buckets += 1
+
+        self._qdigest[parent_bucket_id] = family_counts
+        self._delete_bucket_if_exists(current_bucket_id)
+        self._delete_bucket_if_exists(sibling_bucket_id)
+
+        return True
+
     cpdef void compress(self) except *:
-        if self._total <= self._compression_factor:
+        """Compress q-digest.
+
+        Note
+        ----
+            The compression of q-digest is made by merge procedure
+            (bottom up) according to q-digest property.
+
+            If number of nodes in the digest is less than the
+            required compression factor, there is no sense to merge.
+
+        """
+        if self._number_of_buckets <= self.compression_factor:
             return
 
         cdef uint8_t level =  self._tree_height
         while level > 0:
-            buckets = self.buckets_on_level(level)
+            buckets = self._buckets_on_level(level)
             for bucket_id in buckets:
-                self.merge_if_needed(bucket_id)
-            print(self._qdigest)
+                self._merge_if_needed(bucket_id)
             level -= 1
 
+    def __repr__(self):
+        return (
+            "<QuantileDigest ("
+            "compression: {}, "
+            "range: [{}, {}], "
+            "with_hashing: {}, "
+            "length: {}"
+            ")>"
+        ).format(
+            self.compression_factor,
+            self._min_range, self._max_range,
+            "on" if self.with_hashing else "off",
+            self._number_of_buckets
+        )
 
-        # Parent of node i is node i / 2, unless i = 1.
-        # Node 1 is the root and has no parent.
+    def __len__(self):
+        """Get number of buckets in q-digest.
 
-        # Left child of node i is node 2i, unless 2i > n,
-        # where n is the number of nodes.
-        # • If 2i > n, node i has no left child.
+        Returns
+        -------
+        :obj:`int`
+            The number of buckets in q-digest.
 
-        # For efficiency,
-        # the data can be stored in such a way that explicit pointers are not
-        # necessary: for node data stored at index i, the two child nodes are at
-        # index (2 * i + 1) and (2 * i + 2); the parent node is (i - 1) // 2
-        # (where // indicates integer division).
+        """
+        return self._number_of_buckets
 
-        # Given a
-        # specified leaf_size (the minimum number of points in any node), it is
-        # possible to show that a balanced tree will have
-        #
-        #     n_levels = 1 + max(0, floor(log2((n_samples - 1) / leaf_size)))
-        #
-        # in order to satisfy
-        #
-        #     leaf_size <= min(n_points) <= 2 * leaf_size
-        #
-        # with the exception of the special case where n_samples < leaf_size.
-        # for a given number of levels, the number of nodes in the tree is given by
-        #
-        #     n_nodes = 2 ** n_levels - 1
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cpdef size_t count(self):
+        """Number of elements (incl. duplicates) in the q-digest.
 
+        Returns
+        -------
+        :obj:`int`
+            The number of unique elements already in the q-digest.
 
+        Note
+        ----
+            While we can't say exactly which elements in the q-digest,
+            (because the compression is a lossy operation), it's still
+            possible to say how many in total elements were added.
 
+        """
+        return sum(self._qdigest.values())
 
+    cpdef size_t sizeof(self):
+        """Size of the q-digest in bytes.
 
+        Returns
+        -------
+        :obj:`int`
+            Number of bytes allocated for the q-digest.
 
-
+        """
+        raise NotImplementedError

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -1,7 +1,7 @@
 import cython
 
 from libc.math cimport floor, log, round
-from libc.stdint cimport uint32_t, uint8_t, UINT32_MAX
+from libc.stdint cimport uint64_t, uint32_t, uint8_t, UINT32_MAX
 from libc.stdlib cimport rand
 
 from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
@@ -9,7 +9,7 @@ from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
 
 cdef class QuantileDigest:
 
-    def __cinit__(self, const uint8_t compression_factor):
+    def __cinit__(self, const uint8_t range_in_bits, const uint8_t compression_factor):
         """Create qdigest with requested compression factor.
 
         """
@@ -17,28 +17,28 @@ cdef class QuantileDigest:
             raise ValueError("Compression factor")
 
         self._compression_factor = compression_factor
+        self._range_in_bits = range_in_bits
         self._min_range = 0
-        self._max_range = 2**32 - 1  # UINT32_MAX since uint32 hash function
-        
-        self._tree_height = <uint8_t>(log(self._max_range + 1) + 1)  # 32+1=33
-        self._number_of_nodes = 2**self._tree_height - 1 
+        self._max_range = 2**self._range_in_bits - 1
+
+        self._tree_height = self._range_in_bits + 1
+        self._number_of_nodes = 2**self._tree_height - 1
         self._total = 0
 
-        self._seed = <uint8_t>(rand())
+        # self._seed = <uint8_t>(rand())
+
+        # print(UINT32_MAX, self._max_range)
+        # print("_number_of_nodes", self._number_of_nodes)
+        # print("height", self._tree_height)
 
         self._qdigest = {}
-        # https://stackoverflow.com/questions/7403966
 
-        # cdef size_t index
-        # for index in xrange(self.length):
-        #     self._counter[index] = 0
+    # cdef uint32_t _hash(self, object key, uint8_t seed):
+    #     # self.algorithm = "mmh3_x86_32bit"
+    #     # return mmh3_x86_32bit(key, seed)
+    #     return <uint32_t>key
 
-
-    cdef uint32_t _hash(self, object key, uint8_t seed):
-        # self.algorithm = "mmh3_x86_32bit"
-        return mmh3_x86_32bit(key, seed)
-
-    cdef uint32_t _bucket_id(self, uint32_t value):
+    cdef uint64_t _bucket_id(self, uint32_t value):
         # In the full and complete binary tree build for the
         # binary parition of a range [0 .. self._max_range]
         # is the value-th value (from left) in the last level (=height).
@@ -47,23 +47,23 @@ cdef class QuantileDigest:
         # (because exactly self._max_range nodes at the last level).
         return self._number_of_nodes - self._max_range + value
 
-    cpdef void add(self, object element, bint compress=False) except *:
-        cdef uint32_t hashed = self._hash(element, self._seed)
-        if hashed > self._max_range or hashed < self._min_range:
-            raise ValueError("Value out of range")
+    cpdef void add(self, uint32_t element, bint compress=False) except *:
+        # cdef uint32_t hashed = self._hash(element, self._seed)
+        # if hashed > self._max_range or hashed < self._min_range:
+        #     raise ValueError("Value out of range")
 
-        cdef uint32_t canonical_bucket_id = self._bucket_id(hashed)
+        cdef uint64_t canonical_bucket_id = self._bucket_id(element)
 
         path = []
-        cdef uint32_t bucket_id = canonical_bucket_id
-        cdef uint32_t closest_parent_id_in_digest = 0
+        cdef uint64_t bucket_id = canonical_bucket_id
+        cdef uint64_t closest_parent_id_in_digest = 0
         while bucket_id > 0:
             if bucket_id in self._qdigest:
                 closest_parent_id_in_digest = bucket_id
                 break
             bucket_id = bucket_id // 2  # get parent
 
-        assert closest_parent_id_in_digest > 0
+        # assert closest_parent_id_in_digest > 0
 
         if closest_parent_id_in_digest == canonical_bucket_id:
             self._qdigest[canonical_bucket_id] += 1  # update counts
@@ -83,23 +83,35 @@ cdef class QuantileDigest:
 
     cdef bint qdigest_property(self, size_t counts_sum):
         cdef size_t boundary_value = <size_t>(floor(self._total / float(self._compression_factor)))
+        boundary_value = max(<uint8_t>1, boundary_value)
         if counts_sum <= boundary_value:
             return False
         return True
 
-    cdef bint merge_if_needed(self, uint32_t bucket_id):
-        if bucket_id == 1:
+    def debug(self):
+        return self._qdigest
+
+    cdef bint merge_if_needed(self, uint64_t current_bucket_id):
+        if current_bucket_id == 1:
             return False
 
-        cdef uint32_t parent_bucket_id = bucket_id // 2
-        cdef uint32_t sibling_bucket_id = 2 * bucket_id // 2 + 28888
+        cdef uint64_t parent_bucket_id
+        cdef uint64_t sibling_bucket_id
+        cdef uint8_t current_bucket_shift
 
-        if bucket_id not in self._qdigest:
-            # NOTE: might be already removed from the QDigest 
+        # i // 2 -> [2*i//2 + 0, 2*i//2 +1]
+
+        parent_bucket_id, current_bucket_shift = divmod(
+            current_bucket_id, 2)
+
+        sibling_bucket_id = 2 * parent_bucket_id + current_bucket_shift ^ 1
+
+        if current_bucket_id not in self._qdigest:
+            # NOTE: might be already removed from the QDigest
             # after merging because of its sibling
             return False
 
-        cdef size_t bucket_counts = self._qdigest[bucket_id]
+        cdef size_t bucket_counts = self._qdigest[current_bucket_id]
         cdef size_t bucket_parent_counts = self._qdigest.get(
             parent_bucket_id, 0)
         cdef size_t bucket_sibling_counts = self._qdigest.get(
@@ -109,13 +121,16 @@ cdef class QuantileDigest:
         if self.qdigest_property(counts):
             return False
 
+        print("count", counts, "<<<", bucket_counts, bucket_sibling_counts, bucket_parent_counts)
+        print("merge", parent_bucket_id, "<==", current_bucket_id, sibling_bucket_id)
+
         if parent_bucket_id not in self._qdigest:
             self._total += 1
 
         self._qdigest[parent_bucket_id] = counts
-        
+
         try:
-            del self._qdigest[bucket_id]
+            del self._qdigest[current_bucket_id]
         except:
             pass
         else:
@@ -130,18 +145,48 @@ cdef class QuantileDigest:
 
         return True
 
-    def get_all_on_level(self, uint8_t level):
-        # k => 2^{k-1} .. 2^{k} - 1
-        for bucket_id in range(2**(level - 1), 2**level):
-            if bucket_id in self._qdigest:
-                yield bucket_id
+    cdef list buckets_on_level(self, uint8_t level):
+        """Get all buckets from qdigest that are on the `level`.
+
+        Parameters
+        ----------
+        level : `int`
+            The level index.
+
+        Returns
+        -------
+        :obj:list
+            List of bucket ids from level `level` that are included in
+            qdigest data structure.
+
+        Note
+        ----
+            For full and complete binary tree built from a binary
+            partition, the buckets from level `k` have
+            indices 2^{k-1} .. 2^{k} - 1.
+
+        """
+        cdef uint64_t bucket_ids_start = 2**(level - 1)
+        cdef uint64_t bucket_ids_end = 2 * bucket_ids_start -  1
+
+        # we iterate over qdigest since it has less buckets,
+        # then the average level (may be do that only if layer > X)
+        cdef list buckets = []
+        for bucket_id in self._qdigest:
+            if bucket_ids_start <= bucket_id <= bucket_ids_end:
+                buckets.append(bucket_id)
+        return buckets
 
     cpdef void compress(self) except *:
+        if self._total <= self._compression_factor:
+            return
+
         cdef uint8_t level =  self._tree_height
         while level > 0:
-            buckets = self.get_all_on_level(self, level)
+            buckets = self.buckets_on_level(level)
             for bucket_id in buckets:
-                self._qdigest.merge_if_needed(bucket_id)
+                self.merge_if_needed(bucket_id)
+            print(self._qdigest)
             level -= 1
 
 

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -91,10 +91,10 @@ cdef class QuantileDigest:
         self.with_hashing = enable_hashing
 
         self._min_range = 0
-        self._max_range = 2**self.range_in_bits - 1
+        self._max_range = 1 << self.range_in_bits - 1
 
         self._tree_height = self.range_in_bits + 1
-        self._max_number_of_nodes = 2**self._tree_height - 1
+        self._max_number_of_nodes = 1 << self._tree_height - 1
 
         self._number_of_buckets = 0
         self._exact_boundary_value = 0
@@ -222,7 +222,7 @@ cdef class QuantileDigest:
             indices 2^{k-1} .. 2^{k} - 1.
 
         """
-        cdef uint64_t bucket_ids_start = 2**(level - 1)
+        cdef uint64_t bucket_ids_start = 1 << (level - 1)
         cdef uint64_t bucket_ids_end = 2 * bucket_ids_start -  1
 
         # NOTE: We iterate over q-digest (instead of the tree)
@@ -237,7 +237,7 @@ cdef class QuantileDigest:
         return buckets
 
     @cython.cdivision(True)
-    cpdef void add(self, object element, bint compress=False) except *:
+    cpdef void add(self, object element, bint compress=False):
         """Add element into the q-digest.
 
         Parameters
@@ -342,7 +342,7 @@ cdef class QuantileDigest:
         """Return q-digest for debug purposes."""
         return self._qdigest
 
-    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id):
+    cdef bint _delete_bucket_if_exists(self, uint64_t bucket_id) except *:
         """Delete bucket from q-digest if it's exists.
 
         Parameters
@@ -425,7 +425,7 @@ cdef class QuantileDigest:
 
         return True
 
-    cpdef void compress(self) except *:
+    cpdef void compress(self):
         """Compress q-digest.
 
         Note

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -2,7 +2,7 @@
 
 Quantile Digest.
 
-Quantile Digest or q-digest is a tree-based stream summary algorithm
+Quantile Digest, or q-digest, is a tree-based stream summary algorithm
 that was proposed by Nisheeth Shrivastava, Subhash Suri et al. in
 2004 in the context of monitoring distributed data
 from sensors.
@@ -101,7 +101,7 @@ cdef class QuantileDigest:
         Returns
         -------
         tuple
-            Tuple of values to sort by and break the tie.
+            A tuple of values to sort by and break the tie.
 
         """
         cdef uint64_t bucket_id = bucket[0]
@@ -124,8 +124,9 @@ cdef class QuantileDigest:
         Note
         ----
             In the full and complete binary tree build for the
-            binary parition of a range [0 .. self._max_range]
-            is the value-th value (from left) in the last level (=height).
+            binary partition of a range [0 .. self._max_range]
+            is the `value`-th value (from left) in the last level
+            (that is equal to the tree's height).
 
             The canonical bucket is a leaf bucket for the inserted value.
 
@@ -152,7 +153,7 @@ cdef class QuantileDigest:
 
         Note
         ----
-            In the full and complete binary tree build parent ID can be
+            In the full and complete binary tree, parent ID can be
             computed as integer division by 2 of the bucket's ID.
 
         """
@@ -168,7 +169,7 @@ cdef class QuantileDigest:
 
         Note
         ----
-            In the full and complete binary tree build every parent bucket
+            In the full and complete binary tree, every parent bucket
             has exactly 2 children. Suppose, the parent id is `i`, then
             children have ids `2 * i` and `2 * i + 1`. Thus, the id of the
             sibling can be computed by the XOR of binary shift of the
@@ -209,10 +210,10 @@ cdef class QuantileDigest:
         cdef uint64_t bucket_ids_start = <uint64_t>1 << (level - 1)
         cdef uint64_t bucket_ids_end = 2 * bucket_ids_start - 1
 
-        # NOTE: We iterate over q-digest (instead of the tree)
-        # since it has less buckets than the average level of full tree.
+        # NOTE: We iterate over q-digest (instead of the tree) since
+        # it has fewer buckets than the average level of a full tree.
         # TODO: Does it make sense to iterate over all possible buckets'
-        # ids if level is low (e.g., if layer < 5)
+        # ids if the level is small (e.g., if layer < 5)?
 
         cdef list buckets = []
         for bucket_id in self._qdigest:
@@ -233,7 +234,7 @@ cdef class QuantileDigest:
             For full and complete binary tree built from a binary
             partition, the buckets from level `k` have
             indices 2^{k-1} .. 2^{k} - 1. Thus, finding the closest
-            power of 2 bigger than the bucket ID will give us the
+            power of 2 bigger than the bucket ID give us the bucket's
             level.
 
         Returns
@@ -259,7 +260,7 @@ cdef class QuantileDigest:
             partition, every bucket is associated with a sub-range
             of the main range.
 
-            The collection of buckets on each levels is the complete
+            The collection of buckets on each level is the complete
             partition of the initial range. Thus, number of buckets
             on level `k` is `2^{k-1}` and, because IDs of the buckets
             associated from left to right, the position of the bucket
@@ -305,7 +306,7 @@ cdef class QuantileDigest:
         Raises
         ------
         ValueError
-            If value of the element is out of range.
+            If the value of the element is out of range.
 
         """
         if element > self._max_range or element < self._min_range:
@@ -344,27 +345,28 @@ cdef class QuantileDigest:
             self.compress()
 
     cdef bint _is_worth_to_store(self, size_t family_counts):
-        """Decide if family of nodes with specified counts is worth to be stored.
+        """Decide if the family of nodes is worth to be stored.
 
         Parameters
         ----------
         family_counts : :obj:`int`
-            The total counts of the family of nodes, parent and its 2
-            children.
+            The total counts of the family of nodes: the parent and its
+            two children.
 
         Note
         ----
             If total counts of the family of nodes (parent and 2 children)
             are satisfy the q-digest property, they are worth to be stored.
 
-            Boundary value for estimate significance of the counts in the
-            q-digest propery is related on the ratio between number of elements
-            already in the q-digest and current compression factor.
+            Boundary value, used to estimate the significance of the counts
+            in the q-digest property, is related to the ratio between
+            the number of elements already in the q-digest and the
+            current compression factor.
 
         Returns
         -------
         bool
-            True if family of nodes is worth to be kept in the q-digest,
+            True if the family of nodes is worth to be kept in the q-digest,
             False otherwise.
 
         """
@@ -388,13 +390,13 @@ cdef class QuantileDigest:
 
         Note
         ----
-            Everytime when bucket if deleted, the number_of_buckets
+            Everytime when a bucket is deleted, the number_of_buckets
             in the q-digest has to be decreased.
 
         Returns
         -------
         bool
-            True if delete was performed, False otherwise.
+            True if the deletion was performed, False otherwise.
 
         """
         try:
@@ -416,13 +418,13 @@ cdef class QuantileDigest:
         Note
         ----
             To optimize q-digest, it's required to merge all non-significant
-            families of nodes (parent and its children) and keep information
-            about family counts at parent node only.
+            families of nodes (a parent and its children) and keep information
+            about family counts at the parent node only.
 
         Returns
         -------
         bool
-            True if merge was performed, False otherwise.
+            True if the node merging was performed, False otherwise.
 
         """
         # NOTE: Bucket might be already removed from the q-digest
@@ -470,7 +472,7 @@ cdef class QuantileDigest:
             (bottom up) according to q-digest property.
 
             If number of nodes in the digest is less than the
-            required compression factor, there is no sense to merge.
+            compression factor, then there is no sense to compress.
 
         """
         if self._number_of_buckets <= self.compression_factor:
@@ -530,13 +532,13 @@ cdef class QuantileDigest:
         Returns
         -------
         :obj:`int`
-            Number of bytes allocated for the q-digest.
+            The number of bytes allocated for the q-digest.
 
         Note
         ----
-            Since we can't calculcate exact size of dict in Cython,
-            this function return some estimation based on ideal size of
-            keys, values of each bucket.
+            Since we can't calculate exact size of a dict in Cython,
+            this function return some estimation based on an ideal
+            size of keys, values of each bucket.
 
         """
         cdef size_t size_of_bucket = sizeof(uint64_t) + sizeof(size_t)
@@ -563,11 +565,11 @@ cdef class QuantileDigest:
             of the `n` values is `quantile * n`.
 
             To calculate the quantile, the q-digest has to be compressed
-            and its buckets have to be sorted in increasing their
+            so its buckets have to be sorted in increasing their
             intervals' upper bounds, breaking ties by the putting smaller
             ranges (thus, smaller bucker IDs) first.
 
-            Afterwords, we scan those sorted list and sum counts of
+            Afterwards, we scan those sorted list and sum counts of
             buckets we have seen until we found some buckets on which
             those counts exceed the rank `quantile * n`. Such bucket
             is reported as the estimate for the requested quantile.
@@ -611,21 +613,21 @@ cdef class QuantileDigest:
         Raises
         ------
         ValueError
-            If value of the element is out of range.
+            If the value of the element is out of range.
 
         Note
         ----
             Given an element, the inverse quantile query
-            is about to find its rank in sorted sequence of values.
+            is about to find its rank in a sorted sequence of values.
 
             To calculate the rank, the q-digest has to be compressed
-            and its buckets have to be sorted in increasing their
+            so its buckets have to be sorted in increasing their
             intervals' upper bounds, breaking ties by the putting smaller
             ranges (thus, smaller bucker IDs) first.
 
-            Afterwords, we scan those sorted list from beginning to the end
+            Afterwards, we scan that sorted list from beginning to the end
             and sum counts of buckets whose interval's upper boundary
-            is less then the requested element's value. That sum is reported
+            is less than the requested element's value. That sum is reported
             as the estimate for the requested rank of the element.
 
         Returns
@@ -665,16 +667,16 @@ cdef class QuantileDigest:
         Raises
         ------
         ValueError
-            If upper boundary smaller or equal to the lower boundary.
+            If the upper boundary smaller or equal to the lower boundary.
         ValueError
-            If upper boundary is out of range.
+            If the upper boundary is out of range.
         ValueError
-            If lower boundary is out of range.
+            If the lower boundary is out of range.
 
         Note
         ----
             Given a value the interval (range) query
-            is about to find number of elements in the given range
+            is about to find the number of elements in the given range
             in the sequence of elements.
 
             To calculate the number of elements, we simply perform two
@@ -706,20 +708,20 @@ cdef class QuantileDigest:
         Parameters
         ----------
         other : QuantileDigest
-            The q-digest to be mered with the current one.
+            The q-digest to be merged with the current one.
 
         Raises
         ------
         ValueError
-            If compression factors differ.
+            If the compression factors differ.
         ValueError
-            If ranges differ.
+            If the ranges differ.
 
         Note
         -----
             The merge is computing by taking the union of the two q-digest
-            and adding the counts of buckets with the same range. Then, the
-            resulting q-digest has to be compressed.
+            and adding the counts of their buckets with the same range.
+            Then, the resulting q-digest has to be compressed.
 
         """
         if other.compression_factor != self.compression_factor:

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -1,0 +1,126 @@
+import cython
+
+from libc.math cimport log, round
+from libc.stdint cimport uint32_t, uint8_t, UINT32_MAX
+from libc.stdlib cimport rand
+
+from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
+
+
+cdef class QuantileDigest:
+
+    def __cinit__(self, const uint8_t compression_factor):
+        """Create qdigest with requested compression factor.
+
+        """
+        if compression_factor < 1:
+            raise ValueError("Compression factor")
+
+        self._compression_factor = compression_factor
+        self._min_range = 0
+        self._max_range = 2**32 - 1  # UINT32_MAX since uint32 hash function
+        
+        self._tree_height = math.log(self._max_range + 1, 2) + 1  # 32+1=33
+        self._number_of_nodes = 2**self._tree_height - 1 
+        self._total = 0
+
+        self._seed = <uint8_t>(rand())
+
+        self._qdigest = list?
+        # https://stackoverflow.com/questions/7403966
+
+        # cdef size_t index
+        # for index in xrange(self.length):
+        #     self._counter[index] = 0
+
+
+    cdef uint32_t _hash(self, object key, uint8_t seed):
+        # self.algorithm = "mmh3_x86_32bit"
+        return mmh3_x86_32bit(key, seed)
+
+    cdef size_t _bucket_id(self, uint32_t value):
+        # In the full and complete binary tree build for the
+        # binary parition of a range [0 .. self._max_range]
+        # is the value-th value (from left) in the last level (=height).
+        # The index of the first node (from left to right)
+        # at the last level is _number_of_nodes - self._max_range
+        # (because exactly self._max_range nodes at the last level).
+        return self._number_of_nodes - self._max_range + value
+
+    cdef void add(self, object element, bint compress=False):
+        hashed = self._hash(element, self._seed)
+        if hashed > self._max_range or hashed < self._min_range:
+            raise ValueError("Value out of range")
+
+        canonical_bucket_id = self._bucket_id(hashed)
+
+        path = []
+        bucket_id = canonical_bucket_id
+        while bucket_id > 0:
+            path.append(bucket_id)
+            bucket_id = bucket_id // 2
+
+        closest_parent_id_in_digest = 0
+        for ind, (bucket_id, _) in enumerate(Digest):
+            if bucket_id in path and bucket_id > closest_parent_id_in_digest:
+                closest_parent_id_in_digest = bucket_id
+                bucket_index = ind
+
+        if closest_parent_id_in_digest == canonical_bucket_id:
+            Digest[ind][1] += 1  # update counts
+        else:
+            Digest.append((canonical_bucket_id, 1))
+            for bucket_id in path[1:]:
+                if bucket_id <= closest_parent_id_in_digest:
+                    # break because path list is sorted on creation
+                    break
+
+                Digest.append((bucket_id, 0))
+
+        self._total += 1
+
+        if compress:
+            self.compress()
+
+    cdef void compress(self):
+
+        while level > 0:
+
+        - build full binary tree from the qdigest
+        - compress it
+        - save qdigest1 
+
+        # Parent of node i is node i / 2, unless i = 1.
+        # Node 1 is the root and has no parent.
+
+        # Left child of node i is node 2i, unless 2i > n,
+        # where n is the number of nodes.
+        # • If 2i > n, node i has no left child.
+
+        # For efficiency,
+        # the data can be stored in such a way that explicit pointers are not
+        # necessary: for node data stored at index i, the two child nodes are at
+        # index (2 * i + 1) and (2 * i + 2); the parent node is (i - 1) // 2
+        # (where // indicates integer division).
+
+        # Given a
+        # specified leaf_size (the minimum number of points in any node), it is
+        # possible to show that a balanced tree will have
+        #
+        #     n_levels = 1 + max(0, floor(log2((n_samples - 1) / leaf_size)))
+        #
+        # in order to satisfy
+        #
+        #     leaf_size <= min(n_points) <= 2 * leaf_size
+        #
+        # with the exception of the special case where n_samples < leaf_size.
+        # for a given number of levels, the number of nodes in the tree is given by
+        #
+        #     n_nodes = 2 ** n_levels - 1
+
+
+
+
+
+
+

--- a/pdsa/rank/qdigest.pyx
+++ b/pdsa/rank/qdigest.pyx
@@ -1,6 +1,6 @@
 import cython
 
-from libc.math cimport log, round
+from libc.math cimport floor, log, round
 from libc.stdint cimport uint32_t, uint8_t, UINT32_MAX
 from libc.stdlib cimport rand
 
@@ -20,13 +20,13 @@ cdef class QuantileDigest:
         self._min_range = 0
         self._max_range = 2**32 - 1  # UINT32_MAX since uint32 hash function
         
-        self._tree_height = math.log(self._max_range + 1, 2) + 1  # 32+1=33
+        self._tree_height = <uint8_t>(log(self._max_range + 1) + 1)  # 32+1=33
         self._number_of_nodes = 2**self._tree_height - 1 
         self._total = 0
 
         self._seed = <uint8_t>(rand())
 
-        self._qdigest = list?
+        self._qdigest = {}
         # https://stackoverflow.com/questions/7403966
 
         # cdef size_t index
@@ -38,7 +38,7 @@ cdef class QuantileDigest:
         # self.algorithm = "mmh3_x86_32bit"
         return mmh3_x86_32bit(key, seed)
 
-    cdef size_t _bucket_id(self, uint32_t value):
+    cdef uint32_t _bucket_id(self, uint32_t value):
         # In the full and complete binary tree build for the
         # binary parition of a range [0 .. self._max_range]
         # is the value-th value (from left) in the last level (=height).
@@ -47,48 +47,103 @@ cdef class QuantileDigest:
         # (because exactly self._max_range nodes at the last level).
         return self._number_of_nodes - self._max_range + value
 
-    cdef void add(self, object element, bint compress=False):
-        hashed = self._hash(element, self._seed)
+    cpdef void add(self, object element, bint compress=False) except *:
+        cdef uint32_t hashed = self._hash(element, self._seed)
         if hashed > self._max_range or hashed < self._min_range:
             raise ValueError("Value out of range")
 
-        canonical_bucket_id = self._bucket_id(hashed)
+        cdef uint32_t canonical_bucket_id = self._bucket_id(hashed)
 
         path = []
-        bucket_id = canonical_bucket_id
+        cdef uint32_t bucket_id = canonical_bucket_id
+        cdef uint32_t closest_parent_id_in_digest = 0
         while bucket_id > 0:
-            path.append(bucket_id)
-            bucket_id = bucket_id // 2
-
-        closest_parent_id_in_digest = 0
-        for ind, (bucket_id, _) in enumerate(Digest):
-            if bucket_id in path and bucket_id > closest_parent_id_in_digest:
+            if bucket_id in self._qdigest:
                 closest_parent_id_in_digest = bucket_id
-                bucket_index = ind
+                break
+            bucket_id = bucket_id // 2  # get parent
+
+        assert closest_parent_id_in_digest > 0
 
         if closest_parent_id_in_digest == canonical_bucket_id:
-            Digest[ind][1] += 1  # update counts
+            self._qdigest[canonical_bucket_id] += 1  # update counts
         else:
-            Digest.append((canonical_bucket_id, 1))
-            for bucket_id in path[1:]:
+            self._qdigest[canonical_bucket_id] = 1
+            bucket_id = canonical_bucket_id
+            while bucket_id > 0:
+                bucket_id = bucket_id // 2
                 if bucket_id <= closest_parent_id_in_digest:
-                    # break because path list is sorted on creation
                     break
-
-                Digest.append((bucket_id, 0))
+                self._qdigest[bucket_id] = 0
 
         self._total += 1
 
         if compress:
             self.compress()
 
-    cdef void compress(self):
+    cdef bint qdigest_property(self, size_t counts_sum):
+        cdef size_t boundary_value = <size_t>(floor(self._total / float(self._compression_factor)))
+        if counts_sum <= boundary_value:
+            return False
+        return True
 
+    cdef bint merge_if_needed(self, uint32_t bucket_id):
+        if bucket_id == 1:
+            return False
+
+        cdef uint32_t parent_bucket_id = bucket_id // 2
+        cdef uint32_t sibling_bucket_id = 2 * bucket_id // 2 + 28888
+
+        if bucket_id not in self._qdigest:
+            # NOTE: might be already removed from the QDigest 
+            # after merging because of its sibling
+            return False
+
+        cdef size_t bucket_counts = self._qdigest[bucket_id]
+        cdef size_t bucket_parent_counts = self._qdigest.get(
+            parent_bucket_id, 0)
+        cdef size_t bucket_sibling_counts = self._qdigest.get(
+            sibling_bucket_id, 0)
+
+        cdef size_t counts = bucket_counts + bucket_parent_counts + bucket_sibling_counts
+        if self.qdigest_property(counts):
+            return False
+
+        if parent_bucket_id not in self._qdigest:
+            self._total += 1
+
+        self._qdigest[parent_bucket_id] = counts
+        
+        try:
+            del self._qdigest[bucket_id]
+        except:
+            pass
+        else:
+            self._total -= 1
+
+        try:
+            del self._qdigest[sibling_bucket_id]
+        except:
+            pass
+        else:
+            self._total -= 1
+
+        return True
+
+    def get_all_on_level(self, uint8_t level):
+        # k => 2^{k-1} .. 2^{k} - 1
+        for bucket_id in range(2**(level - 1), 2**level):
+            if bucket_id in self._qdigest:
+                yield bucket_id
+
+    cpdef void compress(self) except *:
+        cdef uint8_t level =  self._tree_height
         while level > 0:
+            buckets = self.get_all_on_level(self, level)
+            for bucket_id in buckets:
+                self._qdigest.merge_if_needed(bucket_id)
+            level -= 1
 
-        - build full binary tree from the qdigest
-        - compress it
-        - save qdigest1 
 
         # Parent of node i is node i / 2, unless i = 1.
         # Node 1 is the root and has no parent.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ PACKAGES = [
     'pdsa.helpers',
     'pdsa.helpers.hashing',
     'pdsa.helpers.storage',
+    'pdsa.rank',
 ]
 
 
@@ -109,6 +110,16 @@ def setup_package():
             include_dirs=[
                 get_python_inc(plat_specific=True),
                 os.path.join('pdsa/helpers/storage', 'src')
+            ]
+        )
+    )
+    extensions.append(
+        Extension(
+            "pdsa.rank.qdigest",
+            language='c++',
+            sources=['pdsa/rank/qdigest.pyx'],
+            include_dirs=[
+                get_python_inc(plat_specific=True),
             ]
         )
     )

--- a/tests/rank/test_qdigest.py
+++ b/tests/rank/test_qdigest.py
@@ -1,0 +1,59 @@
+import pytest
+
+from pdsa.rank.qdigest import QuantileDigest
+
+
+def test_init():
+    qd = QuantileDigest(3, 5)
+
+    for i in range(1):
+        qd.add(0)
+
+    for i in range(4):
+        qd.add(2)
+
+    for i in range(6):
+        qd.add(3)
+
+    for i in range(1):
+        qd.add(4)
+
+    for i in range(1):
+        qd.add(5)
+
+    for i in range(1):
+        qd.add(6)
+
+    for i in range(1):
+        qd.add(7)
+
+    # for i in range(6):
+    #     qd.add(0)
+
+    # for i in range(1):
+    #     qd.add(1)
+
+    # for i in range(3):
+    #     qd.add(2)
+
+    # for i in range(5):
+    #     qd.add(3)
+
+    # for i in range(1):
+    #     qd.add(4)
+
+    # for i in range(2):
+    #     qd.add(5)
+
+    # for i in range(1):
+    #     qd.add(6)
+
+    print(qd.debug())
+    print(qd.compress())
+
+
+    for i in range(1):
+        qd.add(0)
+    print(qd.debug())
+    print(qd.compress())
+    raise

--- a/tests/rank/test_qdigest.py
+++ b/tests/rank/test_qdigest.py
@@ -4,6 +4,70 @@ from pdsa.rank.qdigest import QuantileDigest
 
 
 def test_init():
+    qd = QuantileDigest(16, 3)
+    assert repr(qd) == (
+        "<QuantileDigest (compression: 3, "
+        "range: [0, 65535], with_hashing: off, "
+        "length: 0)>")
+
+    with pytest.raises(ValueError) as excinfo:
+        QuantileDigest(16, 0)
+    assert str(excinfo.value) == 'Compression factor is too small'
+
+    with pytest.raises(ValueError) as excinfo:
+        QuantileDigest(64, 5, True)
+    assert str(excinfo.value) == 'Only 32-bit hashing is supported'
+
+    with pytest.raises(ValueError) as excinfo:
+        QuantileDigest(64, 5, False)
+    assert str(excinfo.value) == 'Only ranges up to 2^{32} are supported'
+
+
+def test_init_with_hashing():
+    qd = QuantileDigest.create_with_hashing(5)
+    assert repr(qd) == (
+        "<QuantileDigest (compression: 5, "
+        "range: [0, 4294967295], with_hashing: on, "
+        "length: 0)>")
+
+
+def test_add_without_compress():
+    range_in_bits = 3
+    qd = QuantileDigest(range_in_bits, 5)
+
+    for i in range(2**range_in_bits):
+        qd.add(i, False)
+
+    assert len(qd) == 2**(range_in_bits + 1) - 1, "Incorrect number of nodes"
+    assert qd.count() == 2**range_in_bits, "Invalid tree"
+
+
+def test_compress():
+    qd = QuantileDigest(3, 3)
+
+    for i in range(10):
+        qd.add(0)
+
+    assert len(qd) == 4, "Incorrect number of nodes"
+    assert qd.count() == 10, "Invalid counts"
+
+    qd.compress()
+
+    assert len(qd) == 1, "Incorrect number of nodes"
+    assert qd.count() == 10, "Invalid counts"
+
+    qd.add(7)
+
+    assert len(qd) == 5, "Incorrect number of nodes"
+    assert qd.count() == 11, "Invalid counts"
+
+    qd.compress()
+
+    assert len(qd) == 2, "Incorrect number of nodes"
+    assert qd.count() == 11, "Invalid counts"
+
+
+def test_compress_from_shrivastava_example():
     qd = QuantileDigest(3, 5)
 
     for i in range(1):
@@ -27,33 +91,10 @@ def test_init():
     for i in range(1):
         qd.add(7)
 
-    # for i in range(6):
-    #     qd.add(0)
+    assert len(qd) == 14, "Incorrect number of nodes"
+    assert qd.count() == 15, "Invalid counts"
 
-    # for i in range(1):
-    #     qd.add(1)
+    qd.compress()
 
-    # for i in range(3):
-    #     qd.add(2)
-
-    # for i in range(5):
-    #     qd.add(3)
-
-    # for i in range(1):
-    #     qd.add(4)
-
-    # for i in range(2):
-    #     qd.add(5)
-
-    # for i in range(1):
-    #     qd.add(6)
-
-    print(qd.debug())
-    print(qd.compress())
-
-
-    for i in range(1):
-        qd.add(0)
-    print(qd.debug())
-    print(qd.compress())
-    raise
+    assert len(qd) == 5, "Incorrect number of nodes"
+    assert qd.count() == 15, "Invalid counts"

--- a/tests/rank/test_qdigest.py
+++ b/tests/rank/test_qdigest.py
@@ -72,22 +72,16 @@ def test_compress_from_shrivastava_example():
 
     for i in range(1):
         qd.add(0)
-
     for i in range(4):
         qd.add(2)
-
     for i in range(6):
         qd.add(3)
-
     for i in range(1):
         qd.add(4)
-
     for i in range(1):
         qd.add(5)
-
     for i in range(1):
         qd.add(6)
-
     for i in range(1):
         qd.add(7)
 
@@ -108,22 +102,16 @@ def test_queries_from_shrivastava_example():
 
     for i in range(1):
         qd.add(0)
-
     for i in range(4):
         qd.add(2)
-
     for i in range(6):
         qd.add(3)
-
     for i in range(1):
         qd.add(4)
-
     for i in range(1):
         qd.add(5)
-
     for i in range(1):
         qd.add(6)
-
     for i in range(1):
         qd.add(7)
 
@@ -143,3 +131,45 @@ def test_queries_from_shrivastava_example():
 
     num_of_values = qd.interval_query(3, 5)
     assert num_of_values == 6, "Incorrect approx. number of values in interval"
+
+
+def test_merge():
+    qd1 = QuantileDigest(3, 5)
+
+    for i in range(8):
+        qd1.add(0)
+    for i in range(8):
+        qd1.add(1)
+    for i in range(4):
+        qd1.add(2)
+    for i in range(1):
+        qd1.add(3)
+    for i in range(5):
+        qd1.add(4)
+    for i in range(3):
+        qd1.add(5)
+    for i in range(5):
+        qd1.add(6)
+    for i in range(2):
+        qd1.add(7)
+
+    q1_counts = qd1.count()
+    qd1.compress()
+
+    qd2 = QuantileDigest(3, 5)
+
+    for i in range(10):
+        qd2.add(0)
+    for i in range(12):
+        qd2.add(1)
+    for i in range(8):
+        qd2.add(2)
+    for i in range(20):
+        qd2.add(3)
+
+    q2_counts = qd2.count()
+    qd2.compress()
+
+    qd1.merge(qd2)
+    assert qd1.count() == q1_counts + q2_counts, "Incorrect counts"
+    assert len(qd1) == 6, "Incorrect length"

--- a/tests/rank/test_qdigest.py
+++ b/tests/rank/test_qdigest.py
@@ -98,3 +98,48 @@ def test_compress_from_shrivastava_example():
 
     assert len(qd) == 5, "Incorrect number of nodes"
     assert qd.count() == 15, "Invalid counts"
+
+
+def test_queries_from_shrivastava_example():
+    # NOTE: percentiles and rank given by q-digest are
+    # approximated, thus no sense to compare them to the
+    # exact values in a test.
+    qd = QuantileDigest(3, 5)
+
+    for i in range(1):
+        qd.add(0)
+
+    for i in range(4):
+        qd.add(2)
+
+    for i in range(6):
+        qd.add(3)
+
+    for i in range(1):
+        qd.add(4)
+
+    for i in range(1):
+        qd.add(5)
+
+    for i in range(1):
+        qd.add(6)
+
+    for i in range(1):
+        qd.add(7)
+
+    qd.compress()
+
+    median = qd.quantile_query(0.5)
+    assert median == 3, "Incorrect approx. median"
+
+    rank = qd.inverse_quantile_query(3)
+    assert rank == 4, "Incorrect approx. rank"
+
+    percentile85 = qd.quantile_query(0.85)
+    assert percentile85 == 7, "Incorrect approx. 85th percentile"
+
+    rank = qd.inverse_quantile_query(5)
+    assert rank == 10, "Incorrect approx. rank"
+
+    num_of_values = qd.interval_query(3, 5)
+    assert num_of_values == 6, "Incorrect approx. number of values in interval"

--- a/tests/rank/test_qdigest.py
+++ b/tests/rank/test_qdigest.py
@@ -165,15 +165,6 @@ def test_queries_from_shrivastava_example():
     num_of_values = qd.interval_query(3, 5)
     assert num_of_values == 6, "Incorrect approx. number of values in interval"
 
-    qd = QuantileDigest(4, 5)
-    for i in [3,5,8,1,9,5,4,3,5,7]:
-        qd.add(i)
-
-    qd.compress()
-
-    assert qd.inverse_quantile_query(5) == 4
-    assert qd.interval_query(0, 7) == 10
-
 
 def test_merge_empty():
     qd1 = QuantileDigest(3, 5)


### PR DESCRIPTION
Quantile Digest, or q-digest, is a tree-based stream summary algorithm
that was proposed by Nisheeth Shrivastava, Subhash Suri et al. in
2004 in the context of monitoring distributed data
from sensors.

References
----------
[1] Shrivastava, N., et al
    Medians and Beyond: New Aggregation Techniques for Sensor Networks.
    Proceedings of the 2nd International Conference on Embedded Networked Sensor Systems,
    Baltimore, MD, USA - November 03–05, 2004, pp. 58–66, ACM New York, NY (2004)
    https://www.inf.fu-berlin.de/lehre/WS11/Wireless/papers/AgrQdigest.pdf