### PR TITLE
Bump Cython version in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Dependencies
 ---------------------
 
 * Python 3.5+ (http://python.org/download/)
-* Cython 0.25+ (http://cython.org/#download)
+* Cython 0.28+ (http://cython.org/#download)
 
 
 Documentation


### PR DESCRIPTION
Now matches the requirements. pip installation fails with Cython 0.25.2 with the following error

```
| $ pip install pdsa
Collecting pdsa
  Using cached https://files.pythonhosted.org/packages/6e/23/db2ed7195e69935f1db7d82392e21cb4383f4c9bde03df6364788d0c9706/pdsa-0.4.0.tar.gz
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/6h/njjvvnrx27s6qkws4jpk5ntw0000gn/T/pip-install-6ktedce9/pdsa/setup.py", line 170, in <module>
        setup_package()
      File "/private/var/folders/6h/njjvvnrx27s6qkws4jpk5ntw0000gn/T/pip-install-6ktedce9/pdsa/setup.py", line 151, in setup_package
        compiler_directives={"language_level": "3str"}
      File ".../lib/python3.6/site-packages/Cython/Build/Dependencies.py", line 807, in cythonize
        c_options = CompilationOptions(**options)
      File ".../lib/python3.6/site-packages/Cython/Compiler/Main.py", line 566, in __init__
        options['language_level'] = int(directives['language_level'])
    ValueError: invalid literal for int() with base 10: '3str'
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/6h/njjvvnrx27s6qkws4jpk5ntw0000gn/T/pip-install-6ktedce9/pdsa/
```