### PR TITLE
Fix cardinality tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - bin/pip3 install pytest-random-order
 
 script:
-  - PYTHONPATH=$PWD:$PYTHONPATH bin/py.test -m 'not ignore' --pep8 --random-order-bucket=global tests
+  - PYTHONPATH=$PWD:$PYTHONPATH bin/py.test -m 'not ignore' --pep8 --random-order-seed=73 tests
 
 notifications:
   email: false

--- a/tests/cardinality/test_hyperloglog.py
+++ b/tests/cardinality/test_hyperloglog.py
@@ -48,10 +48,10 @@ def test_count():
             # they will be tested in another test.
             continue
 
-        error = abs(cardinality - hll.count()) / float(cardinality)
+        error = (cardinality - hll.count()) / float(cardinality)
         errors.append(error)
 
-    avg_error = sum(errors) / float(len(errors))
+    avg_error = abs(sum(errors)) / float(len(errors))
 
     assert avg_error >= 0
     assert avg_error <= std
@@ -70,10 +70,10 @@ def test_count_small():
         element = "element_{}".format(i)
         hll.add(element)
 
-        error = abs(cardinality - hll.count()) / float(cardinality)
+        error = (cardinality - hll.count()) / float(cardinality)
         errors.append(error)
 
-    avg_error = sum(errors) / float(len(errors))
+    avg_error = abs(sum(errors)) / float(len(errors))
 
     assert avg_error >= 0
     assert avg_error <= std

--- a/tests/cardinality/test_hyperloglog.py
+++ b/tests/cardinality/test_hyperloglog.py
@@ -35,11 +35,18 @@ def test_count():
 
     errors = []
 
+    boundary = 2.5 * (1 << precision)
+
     cardinality = 0
     for i in range(100000):
         cardinality += 1
         element = "element_{}".format(i)
         hll.add(element)
+
+        if cardinality <= boundary:
+            # Ignore small cardinality estimations,
+            # they will be tested in another test.
+            continue
 
         error = abs(cardinality - hll.count()) / float(cardinality)
         errors.append(error)

--- a/tests/cardinality/test_hyperloglog.py
+++ b/tests/cardinality/test_hyperloglog.py
@@ -36,7 +36,7 @@ def test_count():
     errors = []
 
     cardinality = 0
-    for i in range(10000):
+    for i in range(100000):
         cardinality += 1
         element = "element_{}".format(i)
         hll.add(element)

--- a/tests/cardinality/test_hyperloglog.py
+++ b/tests/cardinality/test_hyperloglog.py
@@ -4,36 +4,6 @@ from math import sqrt
 from pdsa.cardinality.hyperloglog import HyperLogLog
 
 
-LOREM_TEXT = {
-    "text": (
-        "Lorem ipsum dolor sit amet consectetur adipiscing elit Donec quis "
-        "felis at velit pharetra dictum Sed vehicula est at mi lobortis "
-        "vitae suscipit mi aliquet Sed ut pharetra nisl  Donec maximus enim "
-        "sit amet erat ullamcorper ut mattis mauris gravida Nulla sagittis "
-        "quam a arcu pretium iaculis Donec vestibulum tellus nec ligula "
-        "mattis vitae aliquam augue dapibus Curabitur pulvinar elit nec "
-        "blandit pharetra ipsum elit ultrices sem et bibendum lorem arcu "
-        "sit amet arcu Nam pulvinar porta molestie Integer posuere ipsum "
-        "venenatis velit euismod accumsan sed quis nibh Suspendisse libero "
-        "odio tempor ultricies lectus non volutpat rutrum diam Nullam et "
-        "sem eu quam sodales vulputate Nulla condimentum blandit mi ac "
-        "varius quam vehicula id Quisque sit amet molestie lacus ac "
-        "efficitur ante Proin orci lacus fringilla nec eleifend non "
-        "maximus vel ipsum Sed luctus enim tortor cursus semper mauris "
-        "ultrices vel Vivamus eros purus sodales sed lectus at accumsan "
-        "dictum massa Integer pulvinar tortor sagittis tincidunt risus "
-        "non ultricies augue Aenean efficitur justo orci at semper ipsum "
-        "efficitur ut Phasellus tincidunt nibh ut eros bibendum eleifend "
-        "Donec porta risus nec placerat viverra leo justo sollicitudin "
-        "metus a lacinia mi justo ut augue Duis dolor lacus sodales ut "
-        "tortor eu rutrum"
-    ),
-    "num_of_words": 200,
-    "num_of_unique_words": 111,
-    "num_of_unique_words_icase": 109
-}
-
-
 def test_init():
     hll = HyperLogLog(10)
     assert hll.sizeof() == 4096, "Unexpected size in bytes"
@@ -54,44 +24,30 @@ def test_repr():
 def test_add():
     hll = HyperLogLog(10)
 
-    for word in ["test", 1, {"hello": "world"}]:
-        hll.add(word)
+    for element in ["test", 1, {"hello": "world"}]:
+        hll.add(element)
 
 
 def test_count():
-    precision = 6
+    precision = 10
     hll = HyperLogLog(precision)
     std = 1.04 / sqrt(1 << precision)
 
-    assert hll.count() == 0
+    errors = []
 
-    boost = 50 * LOREM_TEXT["num_of_unique_words"]
-    num_of_unique_words = boost * LOREM_TEXT["num_of_unique_words"]
+    cardinality = 0
+    for i in range(10000):
+        cardinality += 1
+        element = "element_{}".format(i)
+        hll.add(element)
 
-    for i in range(boost):
-        for word in LOREM_TEXT["text"].split():
-            hll.add("{}_{}".format(word, i))
+        error = abs(cardinality - hll.count()) / float(cardinality)
+        errors.append(error)
 
-    cardinality = hll.count()
-    assert cardinality >= (1 - 2 * std) * num_of_unique_words
-    assert cardinality <= (1 + 2 * std) * num_of_unique_words
+    avg_error = sum(errors) / float(len(errors))
 
-
-def test_count_large():
-    precision = 6
-    hll = HyperLogLog(precision)
-
-    # NOTE: make n larger than the HLL upper correction threshold
-    boost = 143165576 // LOREM_TEXT["num_of_unique_words"] + 1
-    num_of_unique_words = boost * LOREM_TEXT["num_of_unique_words"]
-
-    for i in range(boost):
-        for word in LOREM_TEXT["text"].split():
-            hll.add("{}_{}".format(word, i))
-
-    cardinality = hll.count()
-    assert cardinality >= 0.7 * num_of_unique_words
-    assert cardinality <= 1.3 * num_of_unique_words
+    assert avg_error >= 0
+    assert avg_error <= std
 
 
 def test_count_small():
@@ -99,15 +55,21 @@ def test_count_small():
     hll = HyperLogLog(precision)
     std = 1.04 / sqrt(1 << precision)
 
-    short = LOREM_TEXT["text"].split()[:100]
-    num_of_unique_words = len(set(short))
+    errors = []
 
-    for word in short:
-        hll.add(word)
+    cardinality = 0
+    for i in range(100):
+        cardinality += 1
+        element = "element_{}".format(i)
+        hll.add(element)
 
-    cardinality = hll.count()
-    assert cardinality >= (1 - 2 * std) * num_of_unique_words
-    assert cardinality <= (1 + 2 * std) * num_of_unique_words
+        error = abs(cardinality - hll.count()) / float(cardinality)
+        errors.append(error)
+
+    avg_error = sum(errors) / float(len(errors))
+
+    assert avg_error >= 0
+    assert avg_error <= std
 
 
 def test_len():

--- a/tests/cardinality/test_linear_counter.py
+++ b/tests/cardinality/test_linear_counter.py
@@ -2,35 +2,6 @@ import pytest
 
 from pdsa.cardinality.linear_counter import LinearCounter
 
-LOREM_TEXT = {
-    "text": (
-        "Lorem ipsum dolor sit amet consectetur adipiscing elit Donec quis "
-        "felis at velit pharetra dictum Sed vehicula est at mi lobortis "
-        "vitae suscipit mi aliquet Sed ut pharetra nisl  Donec maximus enim "
-        "sit amet erat ullamcorper ut mattis mauris gravida Nulla sagittis "
-        "quam a arcu pretium iaculis Donec vestibulum tellus nec ligula "
-        "mattis vitae aliquam augue dapibus Curabitur pulvinar elit nec "
-        "blandit pharetra ipsum elit ultrices sem et bibendum lorem arcu "
-        "sit amet arcu Nam pulvinar porta molestie Integer posuere ipsum "
-        "venenatis velit euismod accumsan sed quis nibh Suspendisse libero "
-        "odio tempor ultricies lectus non volutpat rutrum diam Nullam et "
-        "sem eu quam sodales vulputate Nulla condimentum blandit mi ac "
-        "varius quam vehicula id Quisque sit amet molestie lacus ac "
-        "efficitur ante Proin orci lacus fringilla nec eleifend non "
-        "maximus vel ipsum Sed luctus enim tortor cursus semper mauris "
-        "ultrices vel Vivamus eros purus sodales sed lectus at accumsan "
-        "dictum massa Integer pulvinar tortor sagittis tincidunt risus "
-        "non ultricies augue Aenean efficitur justo orci at semper ipsum "
-        "efficitur ut Phasellus tincidunt nibh ut eros bibendum eleifend "
-        "Donec porta risus nec placerat viverra leo justo sollicitudin "
-        "metus a lacinia mi justo ut augue Duis dolor lacus sodales ut "
-        "tortor eu rutrum"
-    ),
-    "num_of_words": 200,
-    "num_of_unique_words": 111,
-    "num_of_unique_words_icase": 109
-}
-
 
 def test_init():
     lc = LinearCounter(8000)
@@ -54,7 +25,7 @@ def test_add():
         lc.add(word)
 
 
-def test_count():
+def test_count_small():
     lc = LinearCounter(100000)
 
     assert lc.count() == 0
@@ -68,14 +39,25 @@ def test_count():
     lc.add("test2")
     assert lc.count() == 2
 
-    del lc
 
+def test_count():
     lc = LinearCounter(100000)
 
-    for word in LOREM_TEXT["text"].split():
-        lc.add(word)
+    errors = []
 
-    assert lc.count() == LOREM_TEXT["num_of_unique_words"]
+    cardinality = 0
+    for i in range(100):
+        cardinality += 1
+        element = "element_{}".format(i)
+        lc.add(element)
+
+        error = abs(cardinality - lc.count()) / float(cardinality)
+        errors.append(error)
+
+    avg_error = sum(errors) / float(len(errors))
+
+    assert avg_error >= 0
+    assert avg_error <= 0.1
 
 
 def test_len():

--- a/tests/cardinality/test_probabilistic_counter.py
+++ b/tests/cardinality/test_probabilistic_counter.py
@@ -47,10 +47,10 @@ def test_count():
             # that we will test in another case.
             continue
 
-        error = abs(cardinality - pc.count()) / float(cardinality)
+        error = (cardinality - pc.count()) / float(cardinality)
         errors.append(error)
 
-    avg_error = sum(errors) / float(len(errors))
+    avg_error = abs(sum(errors)) / float(len(errors))
 
     assert avg_error >= 0
     assert avg_error <= std
@@ -71,10 +71,10 @@ def test_count_small():
         element = "element_{}".format(i)
         pc.add(element)
 
-        error = abs(cardinality - pc.count()) / float(cardinality)
+        error = (cardinality - pc.count()) / float(cardinality)
         errors.append(error)
 
-    avg_error = sum(errors) / float(len(errors))
+    avg_error = abs(sum(errors)) / float(len(errors))
 
     assert avg_error >= 0
     assert avg_error <= 2 * std  # Even with correction, still not so good

--- a/tests/cardinality/test_probabilistic_counter.py
+++ b/tests/cardinality/test_probabilistic_counter.py
@@ -1,36 +1,7 @@
 import pytest
 
+from math import sqrt
 from pdsa.cardinality.probabilistic_counter import ProbabilisticCounter
-
-
-LOREM_TEXT = {
-    "text": (
-        "Lorem ipsum dolor sit amet consectetur adipiscing elit Donec quis "
-        "felis at velit pharetra dictum Sed vehicula est at mi lobortis "
-        "vitae suscipit mi aliquet Sed ut pharetra nisl  Donec maximus enim "
-        "sit amet erat ullamcorper ut mattis mauris gravida Nulla sagittis "
-        "quam a arcu pretium iaculis Donec vestibulum tellus nec ligula "
-        "mattis vitae aliquam augue dapibus Curabitur pulvinar elit nec "
-        "blandit pharetra ipsum elit ultrices sem et bibendum lorem arcu "
-        "sit amet arcu Nam pulvinar porta molestie Integer posuere ipsum "
-        "venenatis velit euismod accumsan sed quis nibh Suspendisse libero "
-        "odio tempor ultricies lectus non volutpat rutrum diam Nullam et "
-        "sem eu quam sodales vulputate Nulla condimentum blandit mi ac "
-        "varius quam vehicula id Quisque sit amet molestie lacus ac "
-        "efficitur ante Proin orci lacus fringilla nec eleifend non "
-        "maximus vel ipsum Sed luctus enim tortor cursus semper mauris "
-        "ultrices vel Vivamus eros purus sodales sed lectus at accumsan "
-        "dictum massa Integer pulvinar tortor sagittis tincidunt risus "
-        "non ultricies augue Aenean efficitur justo orci at semper ipsum "
-        "efficitur ut Phasellus tincidunt nibh ut eros bibendum eleifend "
-        "Donec porta risus nec placerat viverra leo justo sollicitudin "
-        "metus a lacinia mi justo ut augue Duis dolor lacus sodales ut "
-        "tortor eu rutrum"
-    ),
-    "num_of_words": 200,
-    "num_of_unique_words": 111,
-    "num_of_unique_words_icase": 109
-}
 
 
 def test_init():
@@ -56,34 +27,57 @@ def test_add():
         pc.add(word)
 
 
-def test_count_big():
-    pc = ProbabilisticCounter(256)
+def test_count():
+    num_of_counters = 256
+    pc = ProbabilisticCounter(num_of_counters)
+    std = 0.78 / sqrt(num_of_counters)
 
-    # NOTE: make n/m > 50 to avoid correction for small cardinalities usage
-    boost = 50 * LOREM_TEXT["num_of_unique_words"] // 64 + 1
-    num_of_unique_words = boost * LOREM_TEXT["num_of_unique_words"]
+    errors = []
 
-    for i in range(boost):
-        for word in LOREM_TEXT["text"].split():
-            pc.add("{}_{}".format(word, i))
+    boundary = 20 * num_of_counters
 
-    cardinality = pc.count()
-    assert cardinality >= 0.8 * num_of_unique_words
-    assert cardinality <= 1.2 * num_of_unique_words
+    cardinality = 0
+    for i in range(10000):
+        cardinality += 1
+        element = "element_{}".format(i)
+        pc.add(element)
+
+        if cardinality < boundary:
+            # For small cardinalities we need to use correction,
+            # that we will test in another case.
+            continue
+
+        error = abs(cardinality - pc.count()) / float(cardinality)
+        errors.append(error)
+
+    avg_error = sum(errors) / float(len(errors))
+
+    assert avg_error >= 0
+    assert avg_error <= std
 
 
 def test_count_small():
-    pc = ProbabilisticCounter(64, True)
-    assert pc.count() == 0
+    num_of_counters = 256
+    pc = ProbabilisticCounter(
+        num_of_counters, with_small_cardinality_correction=True)
 
-    for word in LOREM_TEXT["text"].split():
-        pc.add(word)
+    std = 0.78 / sqrt(num_of_counters)
 
-    num_of_unique_words = LOREM_TEXT["num_of_unique_words"]
+    errors = []
 
-    cardinality = pc.count()
-    assert cardinality >= 0.5 * num_of_unique_words
-    assert cardinality <= 1.5 * num_of_unique_words
+    cardinality = 0
+    for i in range(1000):
+        cardinality += 1
+        element = "element_{}".format(i)
+        pc.add(element)
+
+        error = abs(cardinality - pc.count()) / float(cardinality)
+        errors.append(error)
+
+    avg_error = sum(errors) / float(len(errors))
+
+    assert avg_error >= 0
+    assert avg_error <= 2 * std  # Even with correction, still not so good
 
 
 def test_len():


### PR DESCRIPTION
Cardinality tests are not trivial due to the expected probabilistic nature of the results. Thus, to have the result that can be tested we need to make enough trials and estimate the expected values.