### PR TITLE
Implement frequency algorithms such as Count Sketch and Count-Min Sketch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,12 +112,13 @@ cythonize.json
 
 
 #PDSA
+pdsa/cardinality/hyperloglog.cpp
+pdsa/cardinality/linear_counter.cpp
+pdsa/cardinality/probabilistic_counter.cpp
 pdsa/helpers/hashing/mmh.cpp
 pdsa/helpers/storage/bitvector.cpp
 pdsa/helpers/storage/bitvector_counter.cpp
-pdsa/cardinality/linear_counter.cpp
-pdsa/cardinality/probabilistic_counter.cpp
-pdsa/cardinality/hyperloglog.cpp
 pdsa/membership/bloom_filter.cpp
 pdsa/membership/counting_bloom_filter.cpp
 pdsa/rank/qdigest.cpp
+pdsa/frequency/count_min_sketch.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ pdsa/membership/bloom_filter.cpp
 pdsa/membership/counting_bloom_filter.cpp
 pdsa/rank/qdigest.cpp
 pdsa/frequency/count_min_sketch.cpp
+pdsa/frequency/count_sketch.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ global-exclude pdsa/cardinality/hyperloglog.cpp
 global-exclude pdsa/cardinality/linear_counter.cpp
 global-exclude pdsa/cardinality/probabilistic_counter.cpp
 global-exclude pdsa/frequency/count_min_sketch.cpp
+global-exclude pdsa/frequency/count_sketch.cpp
 global-exclude pdsa/helpers/hashing/mmh.cpp
 global-exclude pdsa/helpers/storage/bitvector.cpp
 global-exclude pdsa/helpers/storage/bitvector_counter.cpp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,13 +11,13 @@ global-exclude __pycache__/*
 global-exclude *.so
 global-exclude .DS_Store
 
+global-exclude pdsa/cardinality/hyperloglog.cpp
 global-exclude pdsa/cardinality/linear_counter.cpp
 global-exclude pdsa/cardinality/probabilistic_counter.cpp
-global-exclude pdsa/cardinality/hyperloglog.cpp
-global-exclude pdsa/membership/bloom_filter.cpp
-global-exclude pdsa/membership/counting_bloom_filter.cpp
+global-exclude pdsa/frequency/count_min_sketch.cpp
 global-exclude pdsa/helpers/hashing/mmh.cpp
 global-exclude pdsa/helpers/storage/bitvector.cpp
 global-exclude pdsa/helpers/storage/bitvector_counter.cpp
+global-exclude pdsa/membership/bloom_filter.cpp
+global-exclude pdsa/membership/counting_bloom_filter.cpp
 global-exclude pdsa/rank/qdigest.cpp
-

--- a/pdsa/frequency/__init__.py
+++ b/pdsa/frequency/__init__.py
@@ -1,0 +1,4 @@
+from .count_min_sketch import CountMinSketch
+
+
+__all__ = ["CountMinSketch", ]

--- a/pdsa/frequency/count_min_sketch.pxd
+++ b/pdsa/frequency/count_min_sketch.pxd
@@ -1,5 +1,5 @@
 from libc.stdint cimport uint64_t, uint32_t, uint8_t
-from cpython.array cimport array
+
 
 cdef class CountMinSketch:
     cdef uint32_t _MAX_COUNTER_VALUE
@@ -15,5 +15,5 @@ cdef class CountMinSketch:
     cpdef uint32_t frequency(self, object element) except *
     cpdef size_t sizeof(self)
 
-    cdef bint _increment_counter(self, uint64_t index)
+    cdef bint _increment_counter(self, const uint64_t index)
     cdef uint32_t _hash(self, object element, uint8_t seed)

--- a/pdsa/frequency/count_min_sketch.pxd
+++ b/pdsa/frequency/count_min_sketch.pxd
@@ -1,0 +1,19 @@
+from libc.stdint cimport uint64_t, uint32_t, uint8_t
+from cpython.array cimport array
+
+cdef class CountMinSketch:
+    cdef uint32_t _MAX_COUNTER_VALUE
+
+    cdef uint8_t num_of_counters
+    cdef uint32_t length_of_counter
+
+    cdef uint64_t _length
+    cdef uint8_t[:] _seeds
+    cdef uint32_t[:] _counter
+
+    cpdef void add(self, object element) except *
+    cpdef uint32_t frequency(self, object element) except *
+    cpdef size_t sizeof(self)
+
+    cdef bint _increment_counter(self, uint64_t index)
+    cdef uint32_t _hash(self, object element, uint8_t seed)

--- a/pdsa/frequency/count_min_sketch.pyx
+++ b/pdsa/frequency/count_min_sketch.pyx
@@ -1,0 +1,256 @@
+"""
+Count-Min Sketch.
+
+Count–Min Sketch is a simple space-efficient probabilistic data structure
+that is used to estimate frequencies of elements in data streams and can
+address the Heavy hitters problem. It was presented in 2003 [1] by
+Graham Cormode and Shan Muthukrishnan and published in 2005 [2].
+
+References
+----------
+[1] Cormode, G., Muthukrishnan, S.
+    What's hot and what's not: Tracking most frequent items dynamically
+    Proceedings of the 22th ACM SIGMOD-SIGACT-SIGART symposium on Principles
+    of database systems, San Diego, California - June 09-11, 2003,
+    pp. 296–306, ACM New York, NY.
+    http://www.cs.princeton.edu/courses/archive/spr04/cos598B/bib/CormodeM-hot.pdf
+[2] Cormode, G., Muthukrishnan, S.
+    An Improved Data Stream Summary: The Count–Min Sketch and its Applications
+    Journal of Algorithms, Vol. 55 (1), pp. 58–75.
+    http://dimacs.rutgers.edu/~graham/pubs/papers/cm-full.pdf
+
+"""
+import cython
+
+from cpython.array cimport array
+from libc.math cimport ceil, log, M_E
+from libc.stdint cimport uint64_t, uint32_t, uint8_t
+from libc.stdint cimport UINT32_MAX
+
+from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
+
+
+cdef class CountMinSketch:
+    """Count-Min Sketch.
+
+    Count-Min Sketch is simple data structure that allows for the indexing
+    of elements from the data stream, results in updating counters,
+    and can provide the number of times every element has been indexed.
+
+    Example
+    -------
+
+    >>> from pdsa.frequency.count_min_sketch import CountMinSketch
+
+    >>> cms = CountMinSketch(5, 2000)
+    >>> cms.add("hello")
+    >>> cms.frequency("hello")
+
+
+    Note
+    -----
+        This implementation uses MurmurHash3 family of hash functions
+        which yields a 32-bit hash value. Thus, the length of the counters
+        is expected to be smaller or equal to the (2^{32} - 1), since
+        we cannot access elements with indexes above this value.
+
+    Note
+    -----
+        This implementation uses 32-bits counters that freeze at their
+        maximal values (2^{32} - 1).
+
+    Attributes
+    ----------
+    num_of_counters : :obj:`int`
+        The number of hash functions.
+    length : :obj:`int`
+        The length of the filter.
+
+    """
+
+    def __cinit__(self, const uint8_t num_of_counters, const uint32_t length_of_counter):
+        """Create sketch from its dimensions.
+
+        Parameters
+        ----------
+        num_of_counters : :obj:`int`
+            The number of counter arrays used in the sketch.
+        length_of_counter : :obj:`int`
+            The number of counters in each counter array.
+
+        Raises
+        ------
+        ValueError
+            If `num of counters` is less than 1.
+        ValueError
+            If `length_of_counter` is less than 1.
+
+        """
+        if num_of_counters < 1:
+            raise ValueError("At least one counter array is required")
+
+        if length_of_counter < 1:
+            raise ValueError("The length of the counter array cannot be less then 1")
+
+        self.num_of_counters = num_of_counters
+        self.length_of_counter = length_of_counter
+
+        self._length = self.num_of_counters * self.length_of_counter
+
+        self._MAX_COUNTER_VALUE = UINT32_MAX
+        self._seeds = array('B', range(self.num_of_counters))
+        self._counter = array('I', range(self._length))
+
+        cdef uint64_t index
+        for index in xrange(self._length):
+            self._counter[index] = 0
+
+    @classmethod
+    def create_from_expected_error(cls, const float deviation, const float error):
+        """Create sketch from the expected frequency deviation and error probability.
+
+        Parameters
+        ----------
+        deviation : float
+            The error ε in answering the paricular query.
+            For example, if we expect 10^7 elements and allow
+            the fixed overestimate of 10, the deviation is 10/10^7 = 10^{-6}.
+        error : float
+            The standard error δ (0 < error < 1).
+
+        Note
+        ----
+            The Count–Min Sketch is approximate and probabilistic at the same
+            time, therefore two parameters, the error ε in answering the paricular
+            query and the error probability δ, affect the space and time
+            requirements. In fact, it provides the guarantee that the estimation
+            error for frequencies will not exceed ε x n
+            with probability at least 1 – δ.
+
+        Raises
+        ------
+        ValueError
+            If `deviation` is 0 or negative.
+        ValueError
+            If `error` not in range (0, 1).
+
+        """
+        if deviation <= 0:
+            raise ValueError("Deviation can't be 0 or negative")
+
+        if error <= 0 or error >= 1:
+            raise ValueError("Error rate shell be in (0, 1)")
+
+        cdef uint8_t num_of_counters = <uint8_t > (ceil(-log(error)))
+        cdef uint32_t length_of_counter = <uint32_t > (ceil(M_E / deviation))
+
+        return cls(max(1, num_of_counters), max(1, length_of_counter))
+
+    cdef uint32_t _hash(self, object key, uint8_t seed):
+        return mmh3_x86_32bit(key, seed)
+
+    def __dealloc__(self):
+        pass
+
+    cdef bint _increment_counter(self, uint64_t index):
+        """Increment counter if the value doesn't exceed maximal allowed.
+
+        Parameters
+        ----------
+        index : obj:`int`
+            The index of the counter to be incremented.
+
+        Note
+        ----
+            When counter reaches its maximal value, we simple freeze it there.
+
+        """
+        if self._counter[index] < self._MAX_COUNTER_VALUE:
+            self._counter[index] += 1
+            return True
+        return False
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cpdef void add(self, object element) except *:
+        """Index element into the sketch.
+
+        Parameters
+        ----------
+        element : obj
+            The element to be indexed into the sketch.
+
+        """
+        cdef uint8_t counter_index
+        cdef uint32_t element_index
+        cdef uint8_t seed
+        cdef uint64_t index
+        for counter_index in range(self.num_of_counters):
+            seed = self._seeds[counter_index]
+            element_index = self._hash(element, seed) % self.length_of_counter
+            index = counter_index * (self.length_of_counter - 1) + element_index
+            self._increment_counter(index)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cpdef uint32_t frequency(self, object element) except *:
+        """Estimate frequency of element.
+
+        Parameters
+        ----------
+        element : obj
+            The element to estimate the frequency for.
+
+        Returns
+        -------
+        uint32_t
+            The frequency of the element.
+
+        """
+        cdef uint8_t counter_index
+        cdef uint32_t element_index
+        cdef uint8_t seed
+        cdef uint64_t index
+        cdef uint32_t frequency = self._MAX_COUNTER_VALUE
+        for counter_index in range(self.num_of_counters):
+            seed = self._seeds[counter_index]
+            element_index = self._hash(element, seed) % self.length_of_counter
+            index = counter_index * (self.length_of_counter - 1) + element_index
+            frequency = min(frequency, self._counter[index])
+        return frequency
+
+    cpdef size_t sizeof(self):
+        """Size of the sketch in bytes.
+
+        Returns
+        -------
+        :obj:`int`
+            Number of bytes allocated for the sketch.
+
+        """
+        return self._length * sizeof(uint32_t)
+
+    def __repr__(self):
+        return "<CountMinSketch ({} x {})>".format(
+            self.num_of_counters,
+            self.length_of_counter
+        )
+
+    def __len__(self):
+        """Get length of the filter.
+
+        Returns
+        -------
+        :obj:`int`
+            The length of the filter.
+
+        """
+        return self._length
+
+
+
+    def debug(self):
+        """Return sketch for debug purposes."""
+        return self._counter

--- a/pdsa/frequency/count_sketch.pxd
+++ b/pdsa/frequency/count_sketch.pxd
@@ -1,0 +1,22 @@
+from libc.stdint cimport uint64_t, uint32_t, uint8_t
+from libc.stdint cimport int32_t
+
+
+cdef class CountSketch:
+    cdef int32_t _MAX_COUNTER_VALUE
+    cdef int32_t _MIN_COUNTER_VALUE
+
+    cdef uint8_t num_of_counters
+    cdef uint32_t length_of_counter
+
+    cdef uint64_t _length
+    cdef uint8_t[:] _seeds
+    cdef uint8_t[:] _seeds_for_switcher
+    cdef int32_t[:] _counter
+
+    cpdef void add(self, object element) except *
+    cpdef uint32_t frequency(self, object element) except *
+    cpdef size_t sizeof(self)
+
+    cdef bint _update_counter(self, const uint64_t index, const bint reverse)
+    cdef uint32_t _hash(self, object element, uint8_t seed)

--- a/pdsa/frequency/count_sketch.pyx
+++ b/pdsa/frequency/count_sketch.pyx
@@ -1,0 +1,287 @@
+"""
+Count Sketch.
+
+Count–Min Sketch is a simple space-efficient probabilistic data structure
+that is used to estimate frequencies of elements in data streams and can
+address the Heavy hitters problem. It was proposed by Moses
+Charikar, Kevin Chen, and Martin Farach-Colton in 2002.
+
+References
+----------
+[1] Charikar, M., Chen, K., Farach-Colton, M.
+    Finding Frequent Items in Data Streams
+    Proceedings of the 29th International Colloquium on Automata, Languages and
+    Programming, pp. 693–703, Springer, Heidelberg.
+    https://www.cs.rutgers.edu/~farach/pubs/FrequentStream.pdf
+
+"""
+import cython
+from statistics import median
+
+from cpython.array cimport array
+from libc.math cimport ceil, log, M_E
+from libc.stdint cimport uint64_t, uint32_t, uint8_t
+from libc.stdint cimport INT32_MAX, INT32_MIN, UINT8_MAX
+from libc.stdlib cimport rand, RAND_MAX
+
+from pdsa.helpers.hashing.mmh cimport mmh3_x86_32bit
+
+
+cdef class CountSketch:
+    """Count-Min Sketch.
+
+    Count-Min Sketch is simple data structure that allows for the indexing
+    of elements from the data stream, results in updating counters,
+    and can provide the number of times every element has been indexed.
+
+    Example
+    -------
+
+    >>> from pdsa.frequency.count_sketch import CountSketch
+
+    >>> cs = CountSketch(5, 2000)
+    >>> cs.add("hello")
+    >>> cs.frequency("hello")
+
+
+    Note
+    -----
+        This implementation uses MurmurHash3 family of hash functions
+        which yields a 32-bit hash value. Thus, the length of the counters
+        is expected to be smaller or equal to the (2^{32} - 1), since
+        we cannot access elements with indexes above this value.
+
+    Note
+    -----
+        This implementation uses 32-bits counters that freeze at their
+        maximal values (2^{32} - 1).
+
+    Attributes
+    ----------
+    num_of_counters : :obj:`int`
+        The number of counter arrays used in the sketch.
+    length_of_counter : :obj:`int`
+        The number of counters in each counter array.
+
+    """
+
+    @cython.cdivision(True)
+    def __cinit__(self, const uint8_t num_of_counters, const uint32_t length_of_counter):
+        """Create sketch from its dimensions.
+
+        Parameters
+        ----------
+        num_of_counters : :obj:`int`
+            The number of counter arrays used in the sketch.
+        length_of_counter : :obj:`int`
+            The number of counters in each counter array.
+
+        Raises
+        ------
+        ValueError
+            If `num of counters` is less than 1.
+        ValueError
+            If `length_of_counter` is less than 1.
+
+        """
+        if num_of_counters < 1:
+            raise ValueError("At least one counter array is required")
+
+        if length_of_counter < 1:
+            raise ValueError("The length of the counter array cannot be less then 1")
+
+        self.num_of_counters = num_of_counters
+        self.length_of_counter = length_of_counter
+
+        self._length = self.num_of_counters * self.length_of_counter
+
+        self._MAX_COUNTER_VALUE = INT32_MAX
+        self._MIN_COUNTER_VALUE = INT32_MIN
+
+        self._seeds = array('B', [
+            <uint8_t >((rand()/RAND_MAX) * UINT8_MAX)
+            for r in range(self.num_of_counters)
+        ])
+        self._seeds_for_switcher = array('B', [
+            <uint8_t >((rand()/RAND_MAX) * UINT8_MAX)
+            for r in range(self.num_of_counters)
+        ])
+
+        self._counter = array('i', range(self._length))
+
+        cdef uint64_t index
+        for index in xrange(self._length):
+            self._counter[index] = 0
+
+    @classmethod
+    def create_from_expected_error(cls, const float deviation, const float error):
+        """Create sketch from the expected frequency deviation and error probability.
+
+        Parameters
+        ----------
+        deviation : float
+            The error ε in answering the paricular query.
+            For example, if we expect 10^7 elements and allow
+            the fixed overestimate of 10, the deviation is 10/10^7 = 10^{-6}.
+        error : float
+            The standard error δ (0 < error < 1).
+
+        Note
+        ----
+            The Count–Min Sketch is approximate and probabilistic at the same
+            time, therefore two parameters, the error ε in answering the paricular
+            query and the error probability δ, affect the space and time
+            requirements. In fact, it provides the guarantee that the estimation
+            error for frequencies will not exceed ε x n
+            with probability at least 1 – δ.
+
+        Raises
+        ------
+        ValueError
+            If `deviation` is smaller than 10^{-5}.
+        ValueError
+            If `error` is not in range (0, 1).
+
+        """
+        if deviation <= 0.00001:
+            raise ValueError("Deviation is too small. Not enough counters")
+
+        if error <= 0 or error >= 1:
+            raise ValueError("Error rate shell be in (0, 1)")
+
+        cdef uint8_t num_of_counters = <uint8_t > (ceil(-log(error)))
+        cdef uint32_t length_of_counter = <uint32_t > (
+            ceil(M_E / (deviation ** 2)))
+
+        return cls(max(1, num_of_counters), max(1, length_of_counter))
+
+    cdef uint32_t _hash(self, object key, uint8_t seed):
+        return mmh3_x86_32bit(key, seed)
+
+    def __dealloc__(self):
+        pass
+
+    cdef bint _update_counter(self, const uint64_t index, const bint reverse):
+        """Increment counter if the value doesn't exceed maximal allowed.
+
+        Parameters
+        ----------
+        index : obj:`int`
+            The index of the counter to be incremented.
+        reverse : bool
+            The flag that indicates whenever we need to increment or decrement.
+
+        Note
+        ----
+            When counter reaches its maximal value, we simple freeze it there.
+            When counter reaches its minimal value, we simple freeze it there.
+
+        """
+        if reverse and self._counter[index] > self._MIN_COUNTER_VALUE:
+            self._counter[index] -= 1
+            return True
+
+        if not reverse and self._counter[index] < self._MAX_COUNTER_VALUE:
+            self._counter[index] += 1
+            return True
+
+        return False
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cpdef void add(self, object element) except *:
+        """Index element into the sketch.
+
+        Parameters
+        ----------
+        element : obj
+            The element to be indexed into the sketch.
+
+        """
+        cdef uint8_t counter_index
+        cdef uint32_t element_index
+        cdef uint8_t seed
+        cdef uint64_t index
+        cdef bint reverse
+        for counter_index in range(self.num_of_counters):
+            seed = self._seeds[counter_index]
+            element_index = self._hash(element, seed) % self.length_of_counter
+            index = counter_index * (self.length_of_counter - 1) + element_index
+
+            seed_for_switcher = self._seeds_for_switcher[counter_index]
+            reverse = self._hash(element, seed_for_switcher) % 2
+            self._update_counter(index, reverse)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cpdef uint32_t frequency(self, object element) except *:
+        """Estimate frequency of element.
+
+        Parameters
+        ----------
+        element : obj
+            The element to estimate the frequency for.
+
+        Returns
+        -------
+        uint32_t
+            The frequency of the element.
+
+        """
+        cdef uint8_t counter_index
+        cdef uint32_t element_index
+        cdef uint8_t seed
+        cdef uint64_t index
+        cdef bint reverse
+
+        cdef uint32_t[:] frequencies
+        frequencies = array('I', [0] * self.num_of_counters)
+
+        for counter_index in range(self.num_of_counters):
+            seed = self._seeds[counter_index]
+            element_index = self._hash(element, seed) % self.length_of_counter
+            index = counter_index * (self.length_of_counter - 1) + element_index
+
+            seed_for_switcher = self._seeds_for_switcher[counter_index]
+            reverse = self._hash(element, seed_for_switcher) % 2
+
+            frequency = self._counter[index] * (-1 if reverse else 1)
+            frequencies[counter_index] = frequency
+
+        return median(frequencies)
+
+    cpdef size_t sizeof(self):
+        """Size of the sketch in bytes.
+
+        Returns
+        -------
+        :obj:`int`
+            Number of bytes allocated for the sketch.
+
+        """
+        return self._length * sizeof(int32_t)
+
+    def __repr__(self):
+        return "<CountSketch ({} x {})>".format(
+            self.num_of_counters,
+            self.length_of_counter
+        )
+
+    def __len__(self):
+        """Get length of the filter.
+
+        Returns
+        -------
+        :obj:`int`
+            The length of the filter.
+
+        """
+        return self._length
+
+
+
+    def debug(self):
+        """Return sketch for debug purposes."""
+        return self._counter

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,16 @@ def setup_package():
     )
     extensions.append(
         Extension(
+            "pdsa.frequency.count_sketch",
+            language='c++',
+            sources=['pdsa/frequency/count_sketch.pyx'],
+            include_dirs=[
+                get_python_inc(plat_specific=True),
+            ]
+        )
+    )
+    extensions.append(
+        Extension(
             "pdsa.rank.qdigest",
             language='c++',
             sources=['pdsa/rank/qdigest.pyx'],

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,11 @@ except ImportError:
 PACKAGES = [
     'pdsa',
     'pdsa.cardinality',
-    'pdsa.membership',
+    'pdsa.frequency',
     'pdsa.helpers',
     'pdsa.helpers.hashing',
     'pdsa.helpers.storage',
+    'pdsa.membership',
     'pdsa.rank',
 ]
 
@@ -120,6 +121,16 @@ def setup_package():
             include_dirs=[
                 get_python_inc(plat_specific=True),
                 os.path.join('pdsa/helpers/storage', 'src')
+            ]
+        )
+    )
+    extensions.append(
+        Extension(
+            "pdsa.frequency.count_min_sketch",
+            language='c++',
+            sources=['pdsa/frequency/count_min_sketch.pyx'],
+            include_dirs=[
+                get_python_inc(plat_specific=True),
             ]
         )
     )

--- a/tests/frequency/test_count_min_sketch.py
+++ b/tests/frequency/test_count_min_sketch.py
@@ -5,7 +5,6 @@ from pdsa.frequency.count_min_sketch import CountMinSketch
 
 def test_init():
     cms = CountMinSketch(2, 4)
-    print(cms.debug())
     assert cms.sizeof() == 32, 'Unexpected size in bytes'
 
     with pytest.raises(ValueError) as excinfo:
@@ -19,23 +18,23 @@ def test_init():
     )
 
 
-def create_from_expected_error():
-    cms = CountMinSketch.create_from_expected_error(0.0000001, 0.01)
-    assert len(cms) == 13591400, 'Unexpected length'
-    assert cms.sizeof() == 54365600, 'Unexpected size in bytes'
+def test_create_from_expected_error():
+    cms = CountMinSketch.create_from_expected_error(0.000001, 0.01)
+    assert repr(cms) == "<CountMinSketch (5 x 2718282)>"
+    assert len(cms) == 13591410, 'Unexpected length'
+    assert cms.sizeof() == 54365640, 'Unexpected size in bytes'
 
     with pytest.raises(ValueError) as excinfo:
         cms = CountMinSketch.create_from_expected_error(0.001, 2)
     assert str(excinfo.value) == 'Error rate shell be in (0, 1)'
 
     with pytest.raises(ValueError) as excinfo:
-        cms = CountMinSketch.create_from_expected_error(0, 0.02)
-    assert str(excinfo.value) == 'Deviation can\'t be 0 or negative'
+        cs = CountMinSketch.create_from_expected_error(0.0000000000001, 0.02)
+    assert str(excinfo.value) == 'Deviation is too small. Not enough counters'
 
 
 def test_repr():
     cms = CountMinSketch(2, 4)
-
     assert repr(cms) == "<CountMinSketch (2 x 4)>"
 
     cms = CountMinSketch.create_from_expected_error(0.1, 0.01)

--- a/tests/frequency/test_count_min_sketch.py
+++ b/tests/frequency/test_count_min_sketch.py
@@ -1,0 +1,63 @@
+import pytest
+
+from pdsa.frequency.count_min_sketch import CountMinSketch
+
+
+def test_init():
+    cms = CountMinSketch(2, 4)
+    print(cms.debug())
+    assert cms.sizeof() == 32, 'Unexpected size in bytes'
+
+    with pytest.raises(ValueError) as excinfo:
+        cms = CountMinSketch(0, 5)
+    assert str(excinfo.value) == 'At least one counter array is required'
+
+    with pytest.raises(ValueError) as excinfo:
+        cms = CountMinSketch(5, 0)
+    assert str(excinfo.value) == (
+        'The length of the counter array cannot be less then 1'
+    )
+
+
+def create_from_expected_error():
+    cms = CountMinSketch.create_from_expected_error(0.0000001, 0.01)
+    assert len(cms) == 13591400, 'Unexpected length'
+    assert cms.sizeof() == 54365600, 'Unexpected size in bytes'
+
+    with pytest.raises(ValueError) as excinfo:
+        cms = CountMinSketch.create_from_expected_error(0.001, 2)
+    assert str(excinfo.value) == 'Error rate shell be in (0, 1)'
+
+    with pytest.raises(ValueError) as excinfo:
+        cms = CountMinSketch.create_from_expected_error(0, 0.02)
+    assert str(excinfo.value) == 'Deviation can\'t be 0 or negative'
+
+
+def test_repr():
+    cms = CountMinSketch(2, 4)
+
+    assert repr(cms) == "<CountMinSketch (2 x 4)>"
+
+    cms = CountMinSketch.create_from_expected_error(0.1, 0.01)
+    assert repr(cms) == "<CountMinSketch (5 x 28)>"
+
+
+def test_add():
+    cms = CountMinSketch(4, 100)
+
+    for word in ["test", 1, {"hello": "world"}]:
+        cms.add(word)
+        assert cms.frequency(word) == 1, "Can't find frequency for element"
+
+
+def test_frequency():
+    cms = CountMinSketch(4, 100)
+
+    cms.add("test")
+    assert cms.frequency("test") == 1, "Can't find recently added element"
+    assert cms.frequency("test_test") == 0, "False positive detected"
+
+
+def test_len():
+    cms = CountMinSketch(2, 4)
+    assert len(cms) == 8

--- a/tests/frequency/test_count_sketch.py
+++ b/tests/frequency/test_count_sketch.py
@@ -1,0 +1,62 @@
+import pytest
+
+from pdsa.frequency.count_sketch import CountSketch
+
+
+def test_init():
+    cs = CountSketch(2, 4)
+    assert cs.sizeof() == 32, 'Unexpected size in bytes'
+
+    with pytest.raises(ValueError) as excinfo:
+        cs = CountSketch(0, 5)
+    assert str(excinfo.value) == 'At least one counter array is required'
+
+    with pytest.raises(ValueError) as excinfo:
+        cs = CountSketch(5, 0)
+    assert str(excinfo.value) == (
+        'The length of the counter array cannot be less then 1'
+    )
+
+
+def test_create_from_expected_error():
+    cs = CountSketch.create_from_expected_error(0.0001, 0.01)
+    assert repr(cs) == "<CountSketch (5 x 271828209)>"
+    assert len(cs) == 1359141045, 'Unexpected length'
+    assert cs.sizeof() == 5436564180, 'Unexpected size in bytes'
+
+    with pytest.raises(ValueError) as excinfo:
+        cs = CountSketch.create_from_expected_error(0.001, 2)
+    assert str(excinfo.value) == 'Error rate shell be in (0, 1)'
+
+    with pytest.raises(ValueError) as excinfo:
+        cs = CountSketch.create_from_expected_error(0.0000000001, 0.02)
+    assert str(excinfo.value) == 'Deviation is too small. Not enough counters'
+
+
+def test_repr():
+    cs = CountSketch(2, 4)
+    assert repr(cs) == "<CountSketch (2 x 4)>"
+
+    cs = CountSketch.create_from_expected_error(0.1, 0.01)
+    assert repr(cs) == "<CountSketch (5 x 272)>"
+
+
+def test_add():
+    cs = CountSketch(4, 100)
+
+    for word in ["test", 1, {"hello": "world"}]:
+        cs.add(word)
+        assert cs.frequency(word) == 1, "Can't find frequency for element"
+
+
+def test_frequency():
+    cs = CountSketch(4, 100)
+
+    cs.add("test")
+    assert cs.frequency("test") == 1, "Can't find recently added element"
+    assert cs.frequency("test_test") == 0, "False positive detected"
+
+
+def test_len():
+    cs = CountSketch(2, 4)
+    assert len(cs) == 8


### PR DESCRIPTION
Count Sketch and Count–Min Sketch are simple space-efficient probabilistic data structures
that are used to estimate frequencies of elements in data streams and can address the Heavy hitters problem.

Count Sketch was proposed by Moses Charikar, Kevin Chen, and Martin Farach-Colton in 2002.
Count–Min Sketch was presented in 2003 by Graham Cormode and Shan Muthukrishnan and published in 2005.

In the current implementation, we support up to 2^{32} -1 counters (due to 32-bit hash functions) each of 32 bits.